### PR TITLE
Modify Filter Commands

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,8 +31,8 @@ nav:
             - Quests: user-guide/dts/quests.md
             - Pokestops: user-guide/dts/pokestops.md
             - Gyms: user-guide/dts/gyms.md
-            - weather: user-guide/dts/weather.md
-            - nests: user-guide/dts/nests.md
+            - Weather: user-guide/dts/weather.md
+            - Nests: user-guide/dts/nests.md
     - Commands:
         - Subscriptions: commands/subscriptions.md
         - Owner: commands/owner.md

--- a/src/Bot.cs
+++ b/src/Bot.cs
@@ -179,6 +179,7 @@
                 commands.RegisterCommands<Gyms>();
                 commands.RegisterCommands<Quests>();
                 commands.RegisterCommands<Settings>();
+                commands.RegisterCommands<ModifyFilters>();
                 if (serverConfig.Subscriptions.Enabled)
                 {
                     commands.RegisterCommands<Notifications>();

--- a/src/Commands/Input/SubscriptionInput.cs
+++ b/src/Commands/Input/SubscriptionInput.cs
@@ -38,7 +38,7 @@ namespace WhMgr.Commands.Input
             var pokemonMessage = (await _context.RespondEmbed("Enter either the Pokemon name(s) or Pokedex ID(s) separated by a comma to subscribe to (i.e. Mewtwo,Dragonite):", DiscordColor.Blurple)).FirstOrDefault();
             var pokemonSubs = await _context.WaitForUserChoice();
             // Validate the provided pokemon list
-            var validation = PokemonValidation.Validate(pokemonSubs, (int)maxPokemonId);
+            var validation = PokemonValidation.Validate(pokemonSubs, maxPokemonId);
             if (validation == null || validation.Valid.Count == 0)
             {
                 await _context.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(_context.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);

--- a/src/Commands/ModifyFilters.cs
+++ b/src/Commands/ModifyFilters.cs
@@ -6,11 +6,15 @@
 
     using DSharpPlus.CommandsNext;
     using DSharpPlus.CommandsNext.Attributes;
+    using DSharpPlus.Entities;
 
     using WhMgr.Diagnostics;
     using WhMgr.Extensions;
 
-    [Group("filters")]
+    [
+        Group("modify-filters"),
+        RequirePermissions(DSharpPlus.Permissions.KickMembers),
+    ]
     public class ModifyFilters
     {
         private static readonly IEventLogger _logger = EventLogger.GetLogger("FILTERS", Program.LogLevel);
@@ -23,11 +27,34 @@
         }
 
         [
+            Command("list"),
+            Description(""),
+        ]
+        public async Task ListFiltersAsync(CommandContext ctx, DiscordChannel channel)
+        {
+            if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
+                return;
+
+            var guildId = ctx.Guild?.Id ?? ctx.Client.Guilds.Keys.FirstOrDefault(x => _dep.WhConfig.Servers.ContainsKey(x));
+            if (!_dep.WhConfig.Servers.ContainsKey(guildId))
+                return;
+
+            var server = _dep.WhConfig.Servers[guildId];
+
+            var filter = Net.Webhooks.WebhookController.FiltersCache[channel.GuildId][channel.Id];
+            var filterPath = System.IO.Path.Combine(Strings.FiltersFolder, filter);
+            var json = System.IO.File.ReadAllText(filterPath);
+            var obj = Newtonsoft.Json.JsonConvert.DeserializeObject<Alarms.Filters.Models.FilterPokemonObject>(json);
+
+            await ctx.RespondEmbed($"Channel: {channel.Name} Available Pokemon: {string.Join(", ", obj.Pokemon)}");
+        }
+
+        [
             Command("add"),
             //Aliases("", ""),
             Description("")
         ]
-        public async Task AddFilters(CommandContext ctx)
+        public async Task AddFiltersAsync(CommandContext ctx)
         {
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
@@ -40,11 +67,11 @@
         }
 
         [
-            Command("edit"),
+            Command("remove"),
             //Aliases("", ""),
             Description("")
         ]
-        public async Task EditFilters(CommandContext ctx)
+        public async Task RemoveFiltersAsync(CommandContext ctx)
         {
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;

--- a/src/Commands/ModifyFilters.cs
+++ b/src/Commands/ModifyFilters.cs
@@ -1,15 +1,21 @@
 ﻿namespace WhMgr.Commands
 {
     using System;
+    using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
 
     using DSharpPlus.CommandsNext;
     using DSharpPlus.CommandsNext.Attributes;
     using DSharpPlus.Entities;
+    using Newtonsoft.Json;
 
+    using WhMgr.Alarms.Filters.Models;
+    using WhMgr.Data;
     using WhMgr.Diagnostics;
     using WhMgr.Extensions;
+    using WhMgr.Net.Webhooks;
 
     [
         Group("modify-filters"),
@@ -30,7 +36,7 @@
             Command("list"),
             Description(""),
         ]
-        public async Task ListFiltersAsync(CommandContext ctx, DiscordChannel channel)
+        public async Task ListFiltersAsync(CommandContext ctx, string type, DiscordChannel channel)
         {
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
@@ -40,21 +46,31 @@
                 return;
 
             var server = _dep.WhConfig.Servers[guildId];
-
-            var filter = Net.Webhooks.WebhookController.FiltersCache[channel.GuildId][channel.Id];
-            var filterPath = System.IO.Path.Combine(Strings.FiltersFolder, filter);
-            var json = System.IO.File.ReadAllText(filterPath);
-            var obj = Newtonsoft.Json.JsonConvert.DeserializeObject<Alarms.Filters.Models.FilterPokemonObject>(json);
-
-            await ctx.RespondEmbed($"Channel: {channel.Name} Available Pokemon: {string.Join(", ", obj.Pokemon)}");
+            // TODO: Check if guild/channel id exist, if not tell user to wait a few more minutes
+            var filter = WebhookController.FiltersCache[channel.GuildId][channel.Id];
+            var filterPath = Path.Combine(Strings.FiltersFolder, filter);
+            var json = File.ReadAllText(filterPath);
+            switch (type.ToLower())
+            {
+                case "pokemon":
+                    var pokemon = JsonConvert.DeserializeObject<Dictionary<string, FilterPokemonObject>>(json);
+                    var pokemonList = pokemon["pokemon"].Pokemon.Select(x => MasterFile.GetPokemon(x, 0).Name).ToList();
+                    await ctx.RespondEmbed($"**Channel:** {channel.Name}\n**Available Pokemon**\n- {(pokemonList.Count == 0 ? "All" : string.Join("\n- ", pokemonList))}");
+                    break;
+                case "quest":
+                case "quests":
+                    var quest = JsonConvert.DeserializeObject<Dictionary<string, FilterQuestObject>>(json);
+                    var questList = quest["quests"].RewardKeywords;
+                    await ctx.RespondEmbed($"**Channel:** {channel.Name}\n**Available Rewards**\n- {(questList.Count == 0 ? "All": string.Join("\n- ", questList))}");
+                    break;
+            }
         }
 
         [
             Command("add"),
-            //Aliases("", ""),
             Description("")
         ]
-        public async Task AddFiltersAsync(CommandContext ctx)
+        public async Task AddFiltersAsync(CommandContext ctx, string type, DiscordChannel channel, string add)
         {
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
@@ -64,6 +80,36 @@
                 return;
 
             var server = _dep.WhConfig.Servers[guildId];
+
+            var filter = WebhookController.FiltersCache[channel.GuildId][channel.Id];
+            var filterPath = Path.Combine(Strings.FiltersFolder, filter);
+            var json = File.ReadAllText(filterPath);
+            switch (type.ToLower())
+            {
+                case "pokemon":
+                    var pokemonFilter = JsonConvert.DeserializeObject<Dictionary<string, FilterPokemonObject>>(json);
+                    var newPokemonList = pokemonFilter["pokemon"].Pokemon;
+                    var validated = PokemonValidation.Validate(add, _dep.WhConfig.MaxPokemonId);
+                    var validList = validated.Valid.Keys.ToList();
+                    var validPokemonList = validList.Select(x => MasterFile.GetPokemon(x, 0).Name).ToList();
+                    pokemonFilter["pokemon"].Pokemon.AddRange(validList);
+                    var pkmnJson = JsonConvert.SerializeObject(pokemonFilter, Formatting.Indented);
+                    File.WriteAllText(filterPath, pkmnJson);
+                    await ctx.RespondEmbed($"Successfully added Pokemon '{string.Join(", ", validPokemonList)}' to filter {filterPath} for channel: {channel.Name}");
+                    // TODO: Reload alarms
+                    break;
+                case "quest":
+                case "quests":
+                    var questFilter = JsonConvert.DeserializeObject<Dictionary<string, FilterQuestObject>>(json);
+                    var newRewardsList = questFilter["quests"].RewardKeywords;
+                    newRewardsList.AddRange(add.RemoveSpaces());
+                    questFilter["quests"].RewardKeywords = newRewardsList;
+                    var questJson = JsonConvert.SerializeObject(questFilter, Formatting.Indented);
+                    File.WriteAllText(filterPath, questJson);
+                    await ctx.RespondEmbed($"Successfully added Quest reward '{add}' to filter {filterPath} for channel: {channel.Name}");
+                    // TODO: Reload alarms
+                    break;
+            }
         }
 
         [
@@ -71,7 +117,7 @@
             //Aliases("", ""),
             Description("")
         ]
-        public async Task RemoveFiltersAsync(CommandContext ctx)
+        public async Task RemoveFiltersAsync(CommandContext ctx, string type, DiscordChannel channel, string remove)
         {
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
@@ -81,6 +127,37 @@
                 return;
 
             var server = _dep.WhConfig.Servers[guildId];
+
+            var filter = WebhookController.FiltersCache[channel.GuildId][channel.Id];
+            var filterPath = Path.Combine(Strings.FiltersFolder, filter);
+            var json = File.ReadAllText(filterPath);
+            switch (type.ToLower())
+            {
+                case "pokemon":
+                    var pokemonFilter = JsonConvert.DeserializeObject<Dictionary<string, FilterPokemonObject>>(json);
+                    var newPokemonList = pokemonFilter["pokemon"].Pokemon;
+                    var validated = PokemonValidation.Validate(remove, _dep.WhConfig.MaxPokemonId);
+                    var validList = validated.Valid.Keys.ToList();
+                    var validPokemonList = validList.Select(x => MasterFile.GetPokemon(x, 0).Name).ToList();
+                    validList.ForEach(x => pokemonFilter["pokemon"].Pokemon.Remove(x));
+                    var pkmnJson = JsonConvert.SerializeObject(pokemonFilter, Formatting.Indented);
+                    File.WriteAllText(filterPath, pkmnJson);
+                    await ctx.RespondEmbed($"Successfully removed Pokemon '{string.Join(", ", validPokemonList)}' from filter {filterPath} for channel: {channel.Name}");
+                    // TODO: Reload alarms
+                    break;
+                case "quest":
+                case "quests":
+                    var questFilter = JsonConvert.DeserializeObject<Dictionary<string, FilterQuestObject>>(json);
+                    var newRewardsList = questFilter["quests"].RewardKeywords;
+                    var rewardsToRemove = remove.RemoveSpaces();
+                    rewardsToRemove.ForEach(x => newRewardsList.Remove(x));
+                    questFilter["quests"].RewardKeywords = newRewardsList;
+                    var questJson = JsonConvert.SerializeObject(questFilter, Formatting.Indented);
+                    File.WriteAllText(filterPath, questJson);
+                    await ctx.RespondEmbed($"Successfully removed Quest reward '{remove}' from filter {filterPath} for channel: {channel.Name}");
+                    // TODO: Reload alarms
+                    break;
+            }
         }
     }
 }

--- a/src/Commands/ModifyFilters.cs
+++ b/src/Commands/ModifyFilters.cs
@@ -41,11 +41,7 @@
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
 
-            var guildId = ctx.Guild?.Id ?? ctx.Client.Guilds.Keys.FirstOrDefault(x => _dep.WhConfig.Servers.ContainsKey(x));
-            if (!_dep.WhConfig.Servers.ContainsKey(guildId))
-                return;
-
-            var server = _dep.WhConfig.Servers[guildId];
+            var server = _dep.WhConfig.Servers[ctx.Guild.Id];
             // TODO: Check if guild/channel id exist, if not tell user to wait a few more minutes
             var filter = WebhookController.FiltersCache[channel.GuildId][channel.Id];
             var filterPath = Path.Combine(Strings.FiltersFolder, filter);
@@ -75,11 +71,7 @@
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
 
-            var guildId = ctx.Guild?.Id ?? ctx.Client.Guilds.Keys.FirstOrDefault(x => _dep.WhConfig.Servers.ContainsKey(x));
-            if (!_dep.WhConfig.Servers.ContainsKey(guildId))
-                return;
-
-            var server = _dep.WhConfig.Servers[guildId];
+            var server = _dep.WhConfig.Servers[ctx.Guild.Id];
 
             var filter = WebhookController.FiltersCache[channel.GuildId][channel.Id];
             var filterPath = Path.Combine(Strings.FiltersFolder, filter);
@@ -122,11 +114,7 @@
             if (!await ctx.IsDirectMessageSupported(_dep.WhConfig))
                 return;
 
-            var guildId = ctx.Guild?.Id ?? ctx.Client.Guilds.Keys.FirstOrDefault(x => _dep.WhConfig.Servers.ContainsKey(x));
-            if (!_dep.WhConfig.Servers.ContainsKey(guildId))
-                return;
-
-            var server = _dep.WhConfig.Servers[guildId];
+            var server = _dep.WhConfig.Servers[ctx.Guild.Id];
 
             var filter = WebhookController.FiltersCache[channel.GuildId][channel.Id];
             var filterPath = Path.Combine(Strings.FiltersFolder, filter);

--- a/src/Commands/ModifyFilters.cs
+++ b/src/Commands/ModifyFilters.cs
@@ -96,7 +96,7 @@
                     var pkmnJson = JsonConvert.SerializeObject(pokemonFilter, Formatting.Indented);
                     File.WriteAllText(filterPath, pkmnJson);
                     await ctx.RespondEmbed($"Successfully added Pokemon '{string.Join(", ", validPokemonList)}' to filter {filterPath} for channel: {channel.Name}");
-                    // TODO: Reload alarms
+                    _dep.Whm.LoadAlarms();
                     break;
                 case "quest":
                 case "quests":
@@ -107,7 +107,7 @@
                     var questJson = JsonConvert.SerializeObject(questFilter, Formatting.Indented);
                     File.WriteAllText(filterPath, questJson);
                     await ctx.RespondEmbed($"Successfully added Quest reward '{add}' to filter {filterPath} for channel: {channel.Name}");
-                    // TODO: Reload alarms
+                    _dep.Whm.LoadAlarms();
                     break;
             }
         }
@@ -143,7 +143,7 @@
                     var pkmnJson = JsonConvert.SerializeObject(pokemonFilter, Formatting.Indented);
                     File.WriteAllText(filterPath, pkmnJson);
                     await ctx.RespondEmbed($"Successfully removed Pokemon '{string.Join(", ", validPokemonList)}' from filter {filterPath} for channel: {channel.Name}");
-                    // TODO: Reload alarms
+                    _dep.Whm.LoadAlarms();
                     break;
                 case "quest":
                 case "quests":
@@ -155,7 +155,7 @@
                     var questJson = JsonConvert.SerializeObject(questFilter, Formatting.Indented);
                     File.WriteAllText(filterPath, questJson);
                     await ctx.RespondEmbed($"Successfully removed Quest reward '{remove}' from filter {filterPath} for channel: {channel.Name}");
-                    // TODO: Reload alarms
+                    _dep.Whm.LoadAlarms();
                     break;
             }
         }

--- a/src/Commands/Notifications.cs
+++ b/src/Commands/Notifications.cs
@@ -373,7 +373,7 @@ namespace WhMgr.Commands
             var subscribed = new List<string>();
             var isModOrHigher = await ctx.Client.IsModeratorOrHigher(ctx.User.Id, guildId, _dep.WhConfig);
             // Validate the provided pokemon list
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -534,7 +534,7 @@ namespace WhMgr.Commands
                 return;
             }
 
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation.Valid == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -619,7 +619,7 @@ namespace WhMgr.Commands
                 return;
             }
 
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation.Valid == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -715,7 +715,7 @@ namespace WhMgr.Commands
                 return;
             }
 
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation.Valid == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -1040,7 +1040,7 @@ namespace WhMgr.Commands
                 return;
             }
 
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation.Valid == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -1135,7 +1135,7 @@ namespace WhMgr.Commands
                 return;
             }
 
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation.Valid == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -1297,7 +1297,7 @@ namespace WhMgr.Commands
 
             var alreadySubscribed = new List<string>();
             var subscribed = new List<string>();
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);
@@ -1446,7 +1446,7 @@ namespace WhMgr.Commands
                 return;
             }
 
-            var validation = PokemonValidation.Validate(poke, (int)_dep.WhConfig.MaxPokemonId);
+            var validation = PokemonValidation.Validate(poke, _dep.WhConfig.MaxPokemonId);
             if (validation.Valid == null || validation.Valid.Count == 0)
             {
                 await ctx.RespondEmbed(Translator.Instance.Translate("NOTIFY_INVALID_POKEMON_IDS_OR_NAMES").FormatText(ctx.User.Username, string.Join(", ", validation.Invalid)), DiscordColor.Red);

--- a/src/Extensions/PokemonExtensions.cs
+++ b/src/Extensions/PokemonExtensions.cs
@@ -291,7 +291,7 @@
             Invalid = new List<string>();
         }
 
-        public static PokemonValidation Validate(string pokemonList, int maxPokemonId)// = 999)
+        public static PokemonValidation Validate(string pokemonList, uint maxPokemonId)// = 999)
         {
             if (string.IsNullOrEmpty(pokemonList))
                 return null;
@@ -299,7 +299,9 @@
             pokemonList = pokemonList.Replace(" ", "");
 
             PokemonValidation validation;
-            if (pokemonList.Contains("-") && int.TryParse(pokemonList.Split('-')[0], out var startRange) && int.TryParse(pokemonList.Split('-')[1], out var endRange))
+            if (pokemonList.Contains("-") &&
+                uint.TryParse(pokemonList.Split('-')[0], out var startRange) &&
+                uint.TryParse(pokemonList.Split('-')[1], out var endRange))
             {
                 //If `poke` param is a range
                 var range = GetListFromRange(startRange, endRange);
@@ -317,7 +319,7 @@
                 }
 
                 var genRange = Strings.PokemonGenerationRanges[gen];
-                var range = GetListFromRange(genRange.Start, genRange.End);
+                var range = GetListFromRange((uint)genRange.Start, (uint)genRange.End);
                 validation = range.ValidatePokemon();
             }
             else if (string.Compare(pokemonList, Strings.All, true) == 0)
@@ -334,7 +336,7 @@
             return validation;
         }
 
-        public static List<string> GetListFromRange(int startRange, int endRange)
+        public static List<string> GetListFromRange(uint startRange, uint endRange)
         {
             var list = new List<string>();
             for (; startRange <= endRange; startRange++)

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -391,11 +391,14 @@
                 var alarms = LoadAlarms(serverId, serverConfig.AlarmsFile);
                 _alarms.Add(serverId, alarms);
 
-                var filters = GetFilterMappings(alarms);
-                foreach (var filter in filters)
+                ThreadPool.QueueUserWorkItem(_ =>
                 {
-                    FiltersCache.Add(filter.Key, filter.Value);
-                }
+                    var filters = GetFilterMappings(alarms);
+                    foreach (var filter in filters)
+                    {
+                        FiltersCache.Add(filter.Key, filter.Value);
+                    }
+                });
             }
         }
 
@@ -428,7 +431,7 @@
                         dict[webhook.GuildId][webhook.ChannelId] = alarm.FiltersFile;
                     }
                 }
-                Thread.Sleep(1000);
+                Thread.Sleep(5);
             }
             return dict;
         }

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -402,6 +402,8 @@
                         else
                             FiltersCache.Add(filter.Key, filter.Value);
                     }
+
+                    _logger.Info($"Finished building filter cache for guild {serverId}");
                 });
             }
         }

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -382,7 +382,7 @@
         
         #region Alarms Initialization
 
-        private void LoadAlarms()
+        public void LoadAlarms()
         {
             _alarms.Clear();
             

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -385,6 +385,7 @@
         public void LoadAlarms()
         {
             _alarms.Clear();
+            FiltersCache.Clear();
             
             foreach (var (serverId, serverConfig) in _config.Instance.Servers)
             {
@@ -396,10 +397,7 @@
                     var filters = GetFilterMappings(alarms);
                     foreach (var filter in filters)
                     {
-                        if (!FiltersCache.ContainsKey(filter.Key))
-                            FiltersCache.Add(filter.Key, filter.Value);
-                        else
-                            FiltersCache[filter.Key] = filter.Value;
+                        FiltersCache.Add(filter.Key, filter.Value);
                     }
                 });
             }

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -397,7 +397,10 @@
                     var filters = GetFilterMappings(alarms);
                     foreach (var filter in filters)
                     {
-                        FiltersCache.Add(filter.Key, filter.Value);
+                        if (FiltersCache.ContainsKey(filter.Key))
+                            FiltersCache[filter.Key] = filter.Value;
+                        else
+                            FiltersCache.Add(filter.Key, filter.Value);
                     }
                 });
             }

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -396,7 +396,10 @@
                     var filters = GetFilterMappings(alarms);
                     foreach (var filter in filters)
                     {
-                        FiltersCache.Add(filter.Key, filter.Value);
+                        if (!FiltersCache.ContainsKey(filter.Key))
+                            FiltersCache.Add(filter.Key, filter.Value);
+                        else
+                            FiltersCache[filter.Key] = filter.Value;
                     }
                 });
             }

--- a/src/Utilities/NetUtil.cs
+++ b/src/Utilities/NetUtil.cs
@@ -88,6 +88,7 @@
             using (var wc = new WebClient())
             {
                 wc.Proxy = null;
+                wc.Headers[HttpRequestHeader.UserAgent] = Strings.BotName;
                 try
                 {
                     return wc.DownloadString(url);


### PR DESCRIPTION
Fixes: #128 
Modify channel filters via commands. All webhooks in an alarm are downloaded and cached upon start. This is needed in order to reference which channel filter the user wants to change without actually referencing the filter name.
```
.modify-filters list #channel pokemon
.modify-filters add #channel pokemon pika,26
.modify-filters remove #channel pokemon larvitar

.modify-filters list #channel quests
```

Currently supports
- Pokemon list
- Quest reward list