### PR TITLE
Add independent log level for Discord clients in Discord server configs

### DIFF
--- a/docs/config/discords.md
+++ b/docs/config/discords.md
@@ -130,6 +130,8 @@ Copy your Discord specific configs to the `bin/discords` folder and reference th
     }
   },
   // Icon style for postings from Discord server.
-  "iconStyle": "Default"
+  "iconStyle": "Default",
+  // Discord client log level, only change if debugging an issue with Discord (default: 4 aka Error)
+  "logLevel": 4
 }
 ```

--- a/examples/discords/discord1.example.json
+++ b/examples/discords/discord1.example.json
@@ -67,5 +67,6 @@
       "channelId": 0
     }
   },
-  "iconStyle": "Default"
+  "iconStyle": "Default",
+  "logLevel": 4
 }

--- a/examples/discords/discord2.example.json
+++ b/examples/discords/discord2.example.json
@@ -67,5 +67,6 @@
       "channelId": 0
     }
   },
-  "iconStyle": "Default"
+  "iconStyle": "Default",
+  "logLevel": 4
 }

--- a/src/Configuration/DiscordServerConfig.cs
+++ b/src/Configuration/DiscordServerConfig.cs
@@ -6,6 +6,8 @@
     using System.Linq;
     using System.Text.Json.Serialization;
 
+    using Microsoft.Extensions.Logging;
+
     using WhMgr.Services.Geofence;
 
     /// <summary>
@@ -95,11 +97,18 @@
         public string IconStyle { get; set; } = "Default";
 
         /// <summary>
+        /// Gets or sets the DiscordClient minimum log level to use for the DSharpPlus
+        /// internal logger (separate from the main logs)
+        /// </summary>
+        public LogLevel LogLevel { get; set; }
+
+        /// <summary>
         /// Instantiate a new <see cref="DiscordServerConfig"/> class
         /// </summary>
         public DiscordServerConfig()
         {
             //Locale = "en";
+            LogLevel = LogLevel.Error;
         }
 
         public void LoadGeofences()

--- a/src/Services/Discord/DiscordClientFactory.cs
+++ b/src/Services/Discord/DiscordClientFactory.cs
@@ -27,10 +27,11 @@
             {
                 AutoReconnect = true,
                 AlwaysCacheMembers = true,
+                // REVIEW: Hmm maybe we should compress the whole stream instead of just payload.
                 GatewayCompressionLevel = GatewayCompressionLevel.Payload,
                 Token = config.Bot?.Token,
                 TokenType = TokenType.Bot,
-                MinimumLogLevel = Microsoft.Extensions.Logging.LogLevel.Error,
+                MinimumLogLevel = config.LogLevel,
                 Intents = DiscordIntents.DirectMessages
                     | DiscordIntents.DirectMessageTyping
                     | DiscordIntents.GuildEmojis


### PR DESCRIPTION
Adds independent `logLevel` property to Discord server configs to help with any debugging with Discord issues per server while maintaining main log level for the rest of the application used from the main config.