### PR TITLE
Add specific Pokemon filtering for events

### DIFF
--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -65,7 +65,9 @@ At a minimum you'll want to make sure you have your webhook listening port set a
     // Minimum IV value for an event Pokemon to have to meet in order to post via Discord channel alarm or direct message subscription.
     "eventMinimumIV": 90,
     // Event Pokemon filtering type
-    "type": "Include"
+    "type": "Include",
+    // Ignore event Pokemon if missing IV stats
+    "ignoreMissingStats": true
   },
   // URL config
   "urls": {

--- a/examples/configs/config.example.json
+++ b/examples/configs/config.example.json
@@ -41,8 +41,13 @@
       "database": "manualdb"
     }
   },
-  "eventPokemonIds": [],
-  "eventMinimumIV": 90,
+  "eventPokemon": {
+    "enabled": false,
+    "pokemonIds": [],
+    "minimumIV": 90,
+    "type": "Include",
+    "ignoreMissingStats": true
+  },
   "urls": {
     "scannerMap": "http://map.example.com/@/{0}/{1}/15"
   },

--- a/src/Configuration/EventPokemonConfig.cs
+++ b/src/Configuration/EventPokemonConfig.cs
@@ -12,7 +12,7 @@
         /// Gets or sets the event Pokemon IDs list
         /// </summary>
         [JsonPropertyName("pokemonIds")]
-        public List<int> PokemonIds { get; set; } = new();
+        public List<uint> PokemonIds { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the minimum IV value for an event Pokemon to be to process

--- a/src/Configuration/EventPokemonConfig.cs
+++ b/src/Configuration/EventPokemonConfig.cs
@@ -28,9 +28,9 @@
         /// Gets or sets the event pokemon filter type.
         /// 
         /// Explaination: Filtering type to use with deemed "event" Pokemon.
-        /// Set to `Exclude` if you do not want the Pokemon reported unless
+        /// Set to `Include` if you do not want the Pokemon reported unless
         /// it meets the minimumIV value set (or is 0% or has PvP ranks).
-        /// Set to `Include` if you only want the Pokemon reported if it meets
+        /// Set to `Exclude` if you only want the Pokemon reported if it meets
         /// the minimum IV value set. No other Pokemon will be reported other
         /// than those in the event list. 
         ///

--- a/src/Configuration/EventPokemonConfig.cs
+++ b/src/Configuration/EventPokemonConfig.cs
@@ -8,6 +8,9 @@
 
     public class EventPokemonConfig
     {
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
         /// <summary>
         /// Gets or sets the event Pokemon IDs list
         /// </summary>
@@ -22,9 +25,17 @@
         public int MinimumIV { get; set; } = 90;
 
         /// <summary>
-        /// Gets or sets the event pokemon filter type
+        /// Gets or sets the event pokemon filter type.
+        /// 
+        /// Explaination: Filtering type to use with deemed "event" Pokemon.
+        /// Set to `Exclude` if you do not want the Pokemon reported unless
+        /// it meets the minimumIV value set (or is 0% or has PvP ranks).
+        /// Set to `Include` if you only want the Pokemon reported if it meets
+        /// the minimum IV value set. No other Pokemon will be reported other
+        /// than those in the event list. 
+        ///
         /// </summary>
         [JsonPropertyName("type")]
         public FilterType FilterType { get; set; }
-    }
+}
 }

--- a/src/Configuration/EventPokemonConfig.cs
+++ b/src/Configuration/EventPokemonConfig.cs
@@ -8,21 +8,27 @@
 
     public class EventPokemonConfig
     {
+        /// <summary>
+        /// Gets or sets a value determining whether to enable the event Pokemon
+        /// filtering.
+        /// </summary>
         [JsonPropertyName("enabled")]
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the event Pokemon IDs list
+        /// Gets or sets the event Pokemon IDs list.
         /// </summary>
         [JsonPropertyName("pokemonIds")]
         public List<uint> PokemonIds { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the minimum IV value for an event Pokemon to be to process
-        /// for channel alarms or direct message subscriptions
+        /// for channel alarms or direct message subscriptions.
         /// </summary>
         [JsonPropertyName("minimumIV")]
         public int MinimumIV { get; set; } = 90;
+
+        // TODO: Add minimumRank EventPokemon config property
 
         /// <summary>
         /// Gets or sets the event pokemon filter type.
@@ -36,6 +42,13 @@
         ///
         /// </summary>
         [JsonPropertyName("type")]
-        public FilterType FilterType { get; set; }
+        public FilterType FilterType { get; set; } = FilterType.Include;
+
+        /// <summary>
+        /// Gets or sets a value determining whether to ignore event Pokemon
+        /// missing IV stats.
+        /// </summary>
+        [JsonPropertyName("ignoreMissingStats")]
+        public bool IgnoreMissingStats { get; set; } = true;
 }
 }

--- a/src/Services/Webhook/Models/PokemonData.cs
+++ b/src/Services/Webhook/Models/PokemonData.cs
@@ -42,31 +42,33 @@
             JsonIgnore,
             NotMapped,
         ]
-        public string IV
-        {
-            get
-            {
-                if (Attack == null || Defense == null || Stamina == null)
-                {
-                    return "?";
-                }
-                return Math.Round(((Attack ?? 0) + (Defense ?? 0) + (Stamina ?? 0)) * 100.0 / 45.0, 1) + "%";
-            }
-        }
+        public string IV => IVReal == -1 ? "?" : IVReal + "%";
 
         [
             JsonIgnore,
             NotMapped,
         ]
-        public string IVRounded
+        public string IVRounded => IVReal == -1 ? "?" : Math.Round(IVReal) + "%";
+
+        [
+
+            JsonIgnore,
+            NotMapped,
+        ]
+        public double IVReal
         {
             get
             {
                 if (Attack == null || Defense == null || Stamina == null)
                 {
-                    return "?";
+                    return -1;
                 }
-                return Math.Round((double)((Attack ?? 0) + (Defense ?? 0) + (Stamina ?? 0)) * 100 / 45) + "%";
+
+                var atk = Attack ?? 0;
+                var def = Defense ?? 0;
+                var sta = Stamina ?? 0;
+
+                return Math.Round((sta + atk + def) * 100.0 / 45.0, 1);
             }
         }
 

--- a/src/Services/Webhook/WebhookProcessorService.cs
+++ b/src/Services/Webhook/WebhookProcessorService.cs
@@ -175,21 +175,6 @@
             if (pokemon.SecondsLeft.TotalMinutes < DespawnTimerMinimumMinutes)
                 return;
 
-            /*
-            // Check if Pokemon is in event Pokemon list
-            if ((_config.Instance.EventPokemon?.PokemonIds.Contains(pokemon.Id) ?? false) &&
-                (_config.Instance.EventPokemon?.PokemonIds.Count ?? 0) > 0)
-            {
-                // Skip Pokemon if no IV stats.
-                if (pokemon.IsMissingStats)
-                    return;
-
-                // Skip Pokemon if IV is greater than 0%, less than 90%, and does not match any PvP league stats.
-                if (pokemon.IVReal > 0 && pokemon.IVReal < _config.Instance.EventPokemon.MinimumIV && !pokemon.HasPvpRankings)
-                    return;
-            }
-            */
-
             // Check if event Pokemon filtering enabled and event Pokemon list is set
             if ((_config.Instance.EventPokemon?.Enabled ?? false) &&
                 (_config.Instance.EventPokemon?.PokemonIds?.Count ?? 0) > 0)
@@ -198,18 +183,13 @@
                 var allowPokemon = pokemon.IVReal == 0
                     || pokemon.IVReal >= _config.Instance.EventPokemon.MinimumIV
                     || pokemon.HasPvpRankings;
-                /*
-                // Skip Pokemon if IV is greater than 0%, less than minimum IV set, and does not contain any PvP league rankings.
-                var shouldExclude = pokemon.IVReal > 0
-                    && pokemon.IVReal < _config.Instance.EventPokemon.MinimumIV
-                    && !pokemon.HasPvpRankings;
-                */
+
                 var filterType = _config.Instance.EventPokemon?.FilterType;
 
                 /*
-                 * Set to `Exclude` if you do not want the Pokemon reported unless
+                 * Set to `Include` if you do not want the Pokemon reported unless
                    it meets the minimum IV value set (or is 0% or has PvP ranks).
-                 * Set to `Include` if you only want the Pokemon reported if it meets
+                 * Set to `Exclude` if you only want the Pokemon reported if it meets
                    the minimum IV value set. No other Pokemon will be reported other
                    than those in the event list.
                 */
@@ -223,6 +203,13 @@
                         case FilterType.Exclude:
                             // Skip Pokemon if no IV stats.
                             if (pokemon.IsMissingStats) return;
+                            // Only allow Pokemon if meets IV/PvP criteria
+                            if (!allowPokemon) return;
+                            break;
+                        case FilterType.Include:
+                            // TODO: Make IsMissingStats configurable for EventPokemon config section
+                            if (pokemon.IsMissingStats) return;
+                            // Only allow Pokemon if meets IV/PvP criteria
                             if (!allowPokemon) return;
                             break;
                     }
@@ -232,9 +219,10 @@
                     // Pokemon not in event Pokemon list
                     switch (filterType)
                     {
-                        case FilterType.Include:
-                            if (!allowPokemon) return;
-                            break;
+                        case FilterType.Exclude:
+                            // Skip any Pokemon that is not in the event list, skip regardless
+                            // if criteria matches
+                            return;
                     }
                 }
             }

--- a/src/Services/Webhook/WebhookProcessorService.cs
+++ b/src/Services/Webhook/WebhookProcessorService.cs
@@ -174,6 +174,19 @@
             if (pokemon.SecondsLeft.TotalMinutes < DespawnTimerMinimumMinutes)
                 return;
 
+            // Check if Pokemon is in event Pokemon list
+            if ((_config.Instance.EventPokemon?.PokemonIds.Contains(pokemon.Id) ?? false) &&
+                (_config.Instance.EventPokemon?.PokemonIds.Count ?? 0) > 0)
+            {
+                // Skip Pokemon if no IV stats.
+                if (pokemon.IsMissingStats)
+                    return;
+
+                // Skip Pokemon if IV is greater than 0%, less than 90%, and does not match any PvP league stats.
+                if (pokemon.IVReal > 0 && pokemon.IVReal < _config.Instance.EventPokemon.MinimumIV && !pokemon.HasPvpRankings)
+                    return;
+            }
+
             if (CheckForDuplicates)
             {
                 // Lock processed pokemon, check for duplicates of incoming pokemon

--- a/src/Services/Webhook/WebhookProcessorService.cs
+++ b/src/Services/Webhook/WebhookProcessorService.cs
@@ -172,60 +172,14 @@
             }
             pokemon.SetTimes();
 
+            // Check if Pokemon despawn timer has at least the specified minimum minutes
+            // remaining, otherwise skip...
             if (pokemon.SecondsLeft.TotalMinutes < DespawnTimerMinimumMinutes)
                 return;
 
             // Check if event Pokemon filtering enabled and event Pokemon list is set
-            if ((_config.Instance.EventPokemon?.Enabled ?? false) &&
-                (_config.Instance.EventPokemon?.PokemonIds?.Count ?? 0) > 0)
-            {
-                // Only process Pokemon if IV is 0%, greater than or equal to minimum IV set, or has PvP league rankings.
-                var allowPokemon = pokemon.IVReal == 0
-                    || pokemon.IVReal >= _config.Instance.EventPokemon.MinimumIV
-                    || pokemon.HasPvpRankings;
-
-                var filterType = _config.Instance.EventPokemon?.FilterType;
-
-                /*
-                 * Set to `Include` if you do not want the Pokemon reported unless
-                   it meets the minimum IV value set (or is 0% or has PvP ranks).
-                 * Set to `Exclude` if you only want the Pokemon reported if it meets
-                   the minimum IV value set. No other Pokemon will be reported other
-                   than those in the event list.
-                */
-
-                // Check if Pokemon is in event Pokemon list
-                if (_config.Instance.EventPokemon.PokemonIds.Contains(pokemon.Id))
-                {
-                    // Pokemon is in event Pokemon list
-                    switch (filterType)
-                    {
-                        case FilterType.Exclude:
-                            // Skip Pokemon if no IV stats.
-                            if (pokemon.IsMissingStats) return;
-                            // Only allow Pokemon if meets IV/PvP criteria
-                            if (!allowPokemon) return;
-                            break;
-                        case FilterType.Include:
-                            // TODO: Make IsMissingStats configurable for EventPokemon config section
-                            if (pokemon.IsMissingStats) return;
-                            // Only allow Pokemon if meets IV/PvP criteria
-                            if (!allowPokemon) return;
-                            break;
-                    }
-                }
-                else
-                {
-                    // Pokemon not in event Pokemon list
-                    switch (filterType)
-                    {
-                        case FilterType.Exclude:
-                            // Skip any Pokemon that is not in the event list, skip regardless
-                            // if criteria matches
-                            return;
-                    }
-                }
-            }
+            if (!CanProceed(pokemon))
+                return;
 
             if (CheckForDuplicates)
             {
@@ -557,6 +511,63 @@
                     _processedWeather.Remove(weatherId);
                 }
             }
+        }
+
+        private bool CanProceed(PokemonData pokemon)
+        {
+            // Check if event Pokemon filtering enabled and event Pokemon list is set
+            if ((_config.Instance.EventPokemon?.Enabled ?? false) &&
+                (_config.Instance.EventPokemon?.PokemonIds?.Count ?? 0) > 0)
+            {
+                // Only process Pokemon if IV is 0%, greater than or equal to minimum IV set, or has PvP league rankings.
+                var allowPokemon = pokemon.IVReal == 0
+                    || pokemon.IVReal >= _config.Instance.EventPokemon.MinimumIV
+                    || pokemon.HasPvpRankings;
+
+                var filterType = _config.Instance.EventPokemon?.FilterType;
+                var ignoreMissingStats = _config.Instance.EventPokemon?.IgnoreMissingStats ?? true;
+
+                /*
+                 * Set to `Include` if you do not want the Pokemon reported unless
+                   it meets the minimum IV value set (or is 0% or has PvP ranks).
+                 * Set to `Exclude` if you only want the Pokemon reported if it meets
+                   the minimum IV value set. No other Pokemon will be reported other
+                   than those in the event list.
+                */
+
+                // Check if Pokemon is in event Pokemon list
+                if (_config.Instance.EventPokemon.PokemonIds.Contains(pokemon.Id))
+                {
+                    // Pokemon is in event Pokemon list
+                    switch (filterType)
+                    {
+                        case FilterType.Exclude:
+                            // Skip Pokemon if no IV stats.
+                            if (ignoreMissingStats && pokemon.IsMissingStats) return false;
+                            // Only allow Pokemon if meets IV/PvP criteria
+                            if (!allowPokemon) return false;
+                            break;
+                        case FilterType.Include:
+                            // TODO: Make IsMissingStats configurable for EventPokemon config section
+                            if (ignoreMissingStats && pokemon.IsMissingStats) return false;
+                            // Only allow Pokemon if meets IV/PvP criteria
+                            if (!allowPokemon) return false;
+                            break;
+                    }
+                }
+                else
+                {
+                    // Pokemon not in event Pokemon list
+                    switch (filterType)
+                    {
+                        case FilterType.Exclude:
+                            // Skip any Pokemon that is not in the event list, skip regardless
+                            // if criteria matches
+                            return false;
+                    }
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/Services/Webhook/WebhookProcessorService.cs
+++ b/src/Services/Webhook/WebhookProcessorService.cs
@@ -12,6 +12,7 @@
     using WhMgr.Configuration;
     using WhMgr.Extensions;
     using WhMgr.Services.Alarms;
+    using WhMgr.Services.Alarms.Filters;
     using WhMgr.Services.Cache;
     using WhMgr.Services.Subscriptions;
     using WhMgr.Services.Webhook.Cache;
@@ -174,6 +175,7 @@
             if (pokemon.SecondsLeft.TotalMinutes < DespawnTimerMinimumMinutes)
                 return;
 
+            /*
             // Check if Pokemon is in event Pokemon list
             if ((_config.Instance.EventPokemon?.PokemonIds.Contains(pokemon.Id) ?? false) &&
                 (_config.Instance.EventPokemon?.PokemonIds.Count ?? 0) > 0)
@@ -185,6 +187,56 @@
                 // Skip Pokemon if IV is greater than 0%, less than 90%, and does not match any PvP league stats.
                 if (pokemon.IVReal > 0 && pokemon.IVReal < _config.Instance.EventPokemon.MinimumIV && !pokemon.HasPvpRankings)
                     return;
+            }
+            */
+
+            // Check if event Pokemon filtering enabled and event Pokemon list is set
+            if ((_config.Instance.EventPokemon?.Enabled ?? false) &&
+                (_config.Instance.EventPokemon?.PokemonIds?.Count ?? 0) > 0)
+            {
+                // Only process Pokemon if IV is 0%, greater than or equal to minimum IV set, or has PvP league rankings.
+                var allowPokemon = pokemon.IVReal == 0
+                    || pokemon.IVReal >= _config.Instance.EventPokemon.MinimumIV
+                    || pokemon.HasPvpRankings;
+                /*
+                // Skip Pokemon if IV is greater than 0%, less than minimum IV set, and does not contain any PvP league rankings.
+                var shouldExclude = pokemon.IVReal > 0
+                    && pokemon.IVReal < _config.Instance.EventPokemon.MinimumIV
+                    && !pokemon.HasPvpRankings;
+                */
+                var filterType = _config.Instance.EventPokemon?.FilterType;
+
+                /*
+                 * Set to `Exclude` if you do not want the Pokemon reported unless
+                   it meets the minimum IV value set (or is 0% or has PvP ranks).
+                 * Set to `Include` if you only want the Pokemon reported if it meets
+                   the minimum IV value set. No other Pokemon will be reported other
+                   than those in the event list.
+                */
+
+                // Check if Pokemon is in event Pokemon list
+                if (_config.Instance.EventPokemon.PokemonIds.Contains(pokemon.Id))
+                {
+                    // Pokemon is in event Pokemon list
+                    switch (filterType)
+                    {
+                        case FilterType.Exclude:
+                            // Skip Pokemon if no IV stats.
+                            if (pokemon.IsMissingStats) return;
+                            if (!allowPokemon) return;
+                            break;
+                    }
+                }
+                else
+                {
+                    // Pokemon not in event Pokemon list
+                    switch (filterType)
+                    {
+                        case FilterType.Include:
+                            if (!allowPokemon) return;
+                            break;
+                    }
+                }
             }
 
             if (CheckForDuplicates)


### PR DESCRIPTION
Adds the functionality of ignoring specific Pokemon unless minimum IV value is met. Filters channel alarms and user subscriptions.

Good for events to prevent channels and subscriptions from being flooded with normally rare Pokemon that get increased spawns.