### PR TITLE
Fixes

### DIFF
--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -11,6 +11,20 @@ At a minimum you'll want to make sure you have your webhook listening port set a
   "port": 8008,
   // Locale language translation
   "locale": "en",
+  // Telemetry reporting
+  "sentry": true,
+  // yourls.org API
+  "shortUrlApi": {
+    // Determines whether the Short URL API is used or not
+    "enabled": false,
+    // ShortURL API (i.e. `https://domain.com/yourls-api.php`)
+    "apiUrl": "https://domain.com/u/api.php",
+    // ShortURL passwordless authentication signature
+    "signature": ""
+  },
+  "stripeApi": {
+    "apiKey": ""
+  },
   // List of Discord servers to connect and post webhook messages to.
   "servers": {
     // Discord server #1 guild ID (replace `000000000000000123` with
@@ -60,6 +74,8 @@ At a minimum you'll want to make sure you have your webhook listening port set a
     }
   },
   "eventPokemon": {
+    // Determines if filtering event Pokemon is enabled or not.
+    "enabled": false,
     // List of Pokemon IDs to treat as event and restrict postings and subscriptions to 90% IV or higher. (Filled in  automatically with `event set` command)  
     "pokemonIds": [],
     // Minimum IV value for an event Pokemon to have to meet in order to post via Discord channel alarm or direct message subscription.
@@ -151,94 +167,16 @@ At a minimum you'll want to make sure you have your webhook listening port set a
   },
   // Custom static map template files for each alarm type
   "staticMaps": {
-    // Static map template for Pokemon
-    "pokemon": {
-      // Static map url template for pokemon
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}",
-      // Static map template file name without extension
-      "template": "pokemon.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for Raids and Eggs
-    "raids": {
-      // Static map url template for raids
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}&team_id={{team_id}}",
-      // Static map template file name without extension
-      "template": "raids.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for Gym team control changes
-    "gyms": {
-      // Static map url template for gyms
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}&team_id={{team_id}}",
-      // Static map template file name without extension
-      "template": "gyms.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for field research quests
-    "quests": {
-      // Static map url template for quests
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}",
-      // Static map template file name without extension
-      "template": "quests.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for Team Rocket invasions
-    "invasions": {
-      // Static map url template for invasions
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}",
-      // Static map template file name without extension
-      "template": "invasions.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for Pokestop lures
-    "lures": {
-      // Static map url template for lures
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}",
-      // Static map template file name without extension
-      "template": "lures.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for weather changes
-    "weather": {
-      // Static map url template for weather
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}&polygon={{polygon}}",
-      // Static map template file name without extension
-      "template": "weather.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    },
-    // Static map template for nest postings
-    "nests": {
-      // Static map url template for nests
-      "url": "http://tiles.example.com/staticmap/{{template_name}}?lat={{lat}}&lon={{lon}}&url2={{url2}}&polygon={{polygon}}",
-      // Static map template file name without extension
-      "template": "nests.example",
-      // Include nearby gyms in static map image  
-      "includeGyms": false,
-      // Include nearby pokestops in static map image
-      "includePokestops": false
-    }
+    // Base url for static map service
+    "url": "http://tiles.example.com:8080",
+    // StaticMap or MultiStaticMap
+    "type": "StaticMap",
+    // Include nearby gyms with static map image  
+    "includeGyms": false,
+    // Include nearby pokestops with static map image  
+    "includePokestops": false,
+    // Including Gyms and Pokestops on the StaticMap only works if `pregenerate` is set to `true`
+    "pregenerate": true
   },
   // Get text message alerts with Twilio.com
   "twilio": {

--- a/docs/config/embeds.md
+++ b/docs/config/embeds.md
@@ -88,7 +88,7 @@ For a list of available dynamic text substitution/replacement options check out 
             "{{#if team_changed}}Gym changed from {{old_gym_team_emoji}} {{old_gym_team}} to {{gym_team_emoji}} {{gym_team}}",
             "{{/if}}{{#if in_battle}}Gym is under attack!",
             "{{/if}}**Slots Available:** {{slots_available}}",
-            "{{#if is_ex}}{{ex_gym_emoji}} Gym!",
+            "{{#if is_ex}}{{ex_emoji}} Gym!",
             "{{/if}}**[Google]({{gmaps_url}}) | [Apple]({{applemaps_url}}) | [Waze]({{wazemaps_url}}) | [Scanner]({{scanmaps_url}})**"
         ],
         "iconUrl": "{{gym_url}}",

--- a/examples/configs/config.example.json
+++ b/examples/configs/config.example.json
@@ -13,7 +13,6 @@
   "stripeApi": {
     "apiKey": ""
   },
-  "maxPokemonId": 898,
   "servers": {
     "000000000000000001": "discord1.example.json",
     "000000000000000002": "discord2.example.json"
@@ -59,7 +58,7 @@
       },
       "Pokemon": {
         "name": "Default_Pokemon",
-        "path": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS/"
+        "path": "https://raw.githubusercontent.com/nileplumb/PkmnShuffleMap/master/UICONS/pokemon/"
       }
       /*
       "Raid",
@@ -102,9 +101,11 @@
   },
   "staticMaps": {
     "url": "http://tiles.example.com:8080",
+    // StaticMap or MultiStaticMap
     "type": "StaticMap",
     "includeGyms": false,
     "includePokestops": false,
+    // Including Gyms and Pokestops on the StaticMap only works if `pregenerate` is set to `true`
     "pregenerate": true
   },
   "twilio": {

--- a/examples/embeds/default.json
+++ b/examples/embeds/default.json
@@ -15,8 +15,7 @@
             "{{#each pvp}}**{{@key}}**",
             "{{#each this}}",
             "#{{rank}} {{getPokemonName pokemonId}} {{getFormName formId}} {{cp}}CP @ L{{level}} {{formatPercentage percentage}}%",
-            "{{/each}}{{/each}}",
-            "{{/if}}**[Google]({{gmaps_url}}) | [Apple]({{applemaps_url}}) | [Waze]({{wazemaps_url}}) | [Scanner]({{scanmaps_url}})**"
+            "{{/each}}{{/each}}{{/if}}**[Google]({{gmaps_url}}) | [Apple]({{applemaps_url}}) | [Waze]({{wazemaps_url}}) | [Scanner]({{scanmaps_url}})**"
         ],
         "iconUrl": "{{pkmn_img_url}}",
         "title": "{{geofence}}",

--- a/examples/templates/Flo/lures.example.json
+++ b/examples/templates/Flo/lures.example.json
@@ -7,19 +7,11 @@
     "height": 175,
     "scale": 1,
     "markers": [{
-        "url": "https://raw.githubusercontent.com/versx/WhMgr-Assets/master/original/misc/pokestop.png",
-        "latitude": #(lat),
-        "longitude": #(lon),
-        "x_offset": 0,
-        "y_offset": 0,
-        "width": 32,
-        "height": 32
-    },{
         "url": "#(url2)",
         "latitude": #(lat),
         "longitude": #(lon),
         "x_offset": 0,
-        "y_offset": -25,
+        "y_offset": 0,
         "width": 32,
         "height": 32
     }]

--- a/examples/templates/Flo/pokemon.example.json
+++ b/examples/templates/Flo/pokemon.example.json
@@ -13,8 +13,8 @@
                 "url": "#(pokestop.marker)",
                 "latitude": #(pokestop.lat),
                 "longitude": #(pokestop.lon),
-                "width": 50,
-                "height": 50
+                "width": 24,
+                "height": 24
             },
             #endfor
         #endif
@@ -24,8 +24,8 @@
                 "url": "#(gym.marker)",
                 "latitude": #(gym.lat),
                 "longitude": #(gym.lon),
-                "width": 50,
-                "height": 50
+                "width": 24,
+                "height": 24
             },
             #endfor
         #endif

--- a/examples/templates/versx/invasions.example.json
+++ b/examples/templates/versx/invasions.example.json
@@ -17,7 +17,7 @@
     },{
         "url": "<%= url2 %>",
         "latitude": <%= lat %>,
-        "longitude": <%= lat %>,
+        "longitude": <%= lon %>,
         "x_offset": 0,
         "y_offset": -25,
         "width": 32,

--- a/examples/templates/versx/lures.example.json
+++ b/examples/templates/versx/lures.example.json
@@ -7,19 +7,11 @@
     "height": 175,
     "scale": 1,
     "markers": [{
-        "url": "https://raw.githubusercontent.com/versx/WhMgr-Assets/master/original/misc/pokestop.png",
-        "latitude": <%= lat %>,
-        "longitude": <%= lon %>,
-        "x_offset": 0,
-        "y_offset": 0,
-        "width": 32,
-        "height": 32
-    },{
         "url": "<%= url2 %>",
         "latitude": <%= lat %>,
         "longitude": <%= lon %>,
         "x_offset": 0,
-        "y_offset": -25,
+        "y_offset": 0,
         "width": 32,
         "height": 32
     }]

--- a/examples/templates/versx/pokemon.example.json
+++ b/examples/templates/versx/pokemon.example.json
@@ -7,25 +7,25 @@
     "height": 175,
     "scale": 1,
     "markers": [
-        <% if (pokestops != null) {
+        <% if (typeof(pokestops) !== 'undefined') {
             pokestops.forEach(function(pokestop) { %>
             {
                 "url": "<%= pokestop.marker %>",
                 "latitude": <%= pokestop.lat %>,
                 "longitude": <%= pokestop.lon %>,
-                "width": 32,
-                "height": 32
+                "width": 24,
+                "height": 24
             },
             <% });
         } %>
-        <% if (gyms != null) {
+        <% if (typeof(gyms) !== 'undefined') {
             gyms.forEach(function(gym) { %>
             {
                 "url": "<%= gym.marker %>",
                 "latitude": <%= gym.lat %>,
                 "longitude": <%= gym.lon %>,
-                "width": 32,
-                "height": 32
+                "width": 24,
+                "height": 24
             },
             <% });
         } %>

--- a/src/Commands/Discord/Feeds.cs
+++ b/src/Commands/Discord/Feeds.cs
@@ -54,7 +54,7 @@
             sb.AppendLine(Translator.Instance.Translate("FEEDS_AVAILABLE_CITY_ROLES"));
             sb.AppendLine($"- {string.Join($"{Environment.NewLine}- ", cityRoles)}");
             sb.AppendLine();
-            sb.AppendLine($"- {Strings.All}");
+            sb.AppendLine($"- {Strings.Defaults.All}");
             sb.AppendLine();
             sb.AppendLine();
             sb.AppendLine(Translator.Instance.Translate("FEEDS_TYPE_COMMAND_ASSIGN_ROLE").FormatText(new { prefix = server.Bot.CommandPrefix }));
@@ -96,7 +96,7 @@
                 return;
             }
 
-            if (string.Compare(cityName, Strings.All, true) == 0)
+            if (string.Compare(cityName, Strings.Defaults.All, true) == 0)
             {
                 await ctx.RespondEmbedAsync(Translator.Instance.Translate("FEEDS_PLEASE_WAIT").FormatText(new { author = ctx.User.Username }), DiscordColor.Green);
                 await AssignAllDefaultFeedRoles(ctx);
@@ -200,7 +200,7 @@
                 return;
             }
 
-            if (string.Compare(cityName, Strings.All, true) == 0)
+            if (string.Compare(cityName, Strings.Defaults.All, true) == 0)
             {
                 await ctx.RespondEmbedAsync(Translator.Instance.Translate("FEEDS_PLEASE_WAIT").FormatText(new { author = ctx.User.Username }), DiscordColor.Green);
                 await RemoveAllDefaultFeedRoles(ctx);

--- a/src/Configuration/DiscordEmbedColorsConfig.cs
+++ b/src/Configuration/DiscordEmbedColorsConfig.cs
@@ -33,7 +33,7 @@
                     new DiscordEmbedColorPokemonPvP { Minimum = 1, Maximum = 3, Color = "#000080" },
                     new DiscordEmbedColorPokemonPvP { Minimum = 4, Maximum = 25, Color = "#800080" },
                     new DiscordEmbedColorPokemonPvP { Minimum = 26, Maximum = 100, Color = "#aa2299" },
-                }
+                },
             };
             Raids = new DiscordEmbedColorRaids();
             Pokestops = new DiscordEmbedColorPokestop();

--- a/src/Defaults.cs
+++ b/src/Defaults.cs
@@ -6,7 +6,6 @@
     using WeatherCondition = POGOProtos.Rpc.GameplayWeatherProto.Types.WeatherCondition;
 
     using WhMgr.Common;
-    using WhMgr.Services.Webhook.Models;
 
     public class Defaults
     {
@@ -50,14 +49,27 @@
         [JsonPropertyName("waze_maps")]
         public string WazeMaps { get; set; }
 
+
+        // Emoji formats and list
         [JsonPropertyName("emojis_list")]
         public List<string> EmojisList { get; set; }
+
+        [JsonPropertyName("emoji_schema")]
+        public string EmojiSchema { get; set; }
+
+        [JsonPropertyName("type_emoji_schema")]
+        public string TypeEmojiSchema { get; set; }
+
 
         [JsonPropertyName("pokemon_generation_ranges")]
         public IReadOnlyDictionary<int, PokemonGenerationRange> PokemonGenerationRanges { get; set; }
 
         [JsonPropertyName("weather_boosts")]
         public IReadOnlyDictionary<WeatherCondition, IReadOnlyList<PokemonType>> WeatherBoosts { get; set; }
+
+
+        [JsonPropertyName("all")]
+        public string All { get; set; }
 
         public Defaults()
         {
@@ -74,6 +86,9 @@
             GoogleMaps = "https://maps.google.com/maps?q={0},{1}";
             AppleMaps = "https://maps.apple.com/maps?daddr={0},{1}";
             WazeMaps = "https://waze.com/ul?ll={0},{1}&navigate=yes";
+
+            EmojiSchema = "<:{0}:{1}>";
+            TypeEmojiSchema = "<:types_{0}:{1}>";
 
             EmojisList = new List<string>
             {
@@ -129,6 +144,8 @@
                 "gender_female",
                 "gender_less",
             };
+
+            All = "All";
 
             PokemonGenerationRanges = new Dictionary<int, PokemonGenerationRange>
             {

--- a/src/Extensions/DiscordExtensions.cs
+++ b/src/Extensions/DiscordExtensions.cs
@@ -456,13 +456,9 @@
 
         #region Colors
 
-        public static DiscordColor BuildPokemonIVColor(this string iv, DiscordEmbedColorsConfig config)
+        public static DiscordColor BuildPokemonIVColor(this double iv, DiscordEmbedColorsConfig config)
         {
-            if (!double.TryParse(iv[0..^1], out var result))
-            {
-                return DiscordColor.White;
-            }
-            var color = config.Pokemon.IV.FirstOrDefault(x => result >= x.Minimum && result <= x.Maximum);
+            var color = config.Pokemon.IV.FirstOrDefault(x => iv >= x.Minimum && iv <= x.Maximum);
             return new DiscordColor(color.Color);
         }
 

--- a/src/Extensions/DiscordExtensions.cs
+++ b/src/Extensions/DiscordExtensions.cs
@@ -459,7 +459,7 @@
         public static DiscordColor BuildPokemonIVColor(this double iv, DiscordEmbedColorsConfig config)
         {
             var color = config.Pokemon.IV.FirstOrDefault(x => iv >= x.Minimum && iv <= x.Maximum);
-            return new DiscordColor(color.Color);
+            return color == null ? DiscordColor.White : new DiscordColor(color.Color);
         }
 
         public static DiscordColor BuildPokemonPvPColor(this int rank, DiscordEmbedColorsConfig config)
@@ -469,7 +469,7 @@
                 return DiscordColor.White;
             }
             var color = config.Pokemon.PvP.FirstOrDefault(x => rank >= x.Minimum && rank <= x.Maximum);
-            return new DiscordColor(color.Color);
+            return color == null ? DiscordColor.White : new DiscordColor(color.Color);
         }
 
         public static DiscordColor BuildRaidColor(this ushort level, DiscordEmbedColorsConfig config)

--- a/src/Extensions/PvpExtensions.cs
+++ b/src/Extensions/PvpExtensions.cs
@@ -49,7 +49,6 @@
             return pokemonIds;
         }
 
-        // TODO: Use for PokemonData class with embed template parsing to filter useless ranks or remove from config
         public static Dictionary<PvpLeague, List<PvpRankData>> GetLeagueRanks(this PokemonData pokemon)
         {
             var dict = new Dictionary<PvpLeague, List<PvpRankData>>();
@@ -85,11 +84,7 @@
                         pvp.Level.HasValue &&
                         pvp.CP.HasValue && pvp.CP <= pvpConfig.MaximumCP)
                     {
-                        //var name = Translator.Instance.GetPokemonName(pvp.PokemonId);
-                        //var form = Translator.Instance.GetFormName(pvp.FormId);
-                        //var pkmnName = string.IsNullOrEmpty(form) ? name : $"{name} ({form})";
                         pvp.Percentage = Math.Round(pvp.Percentage.Value, 2);
-                        //pvp.PokemonName = pkmnName;
                         if (dict.ContainsKey(pokemonPvpLeague))
                         {
                             dict[pokemonPvpLeague].Add(pvp);

--- a/src/Localization/Translator.cs
+++ b/src/Localization/Translator.cs
@@ -47,7 +47,7 @@
                 var locale = Path.GetFileName(file).Replace("_", null);
                 var localeFile = locale;
 
-                var json = await NetUtils.Get(SourceLocaleUrl + locale);
+                var json = await NetUtils.GetAsync(SourceLocaleUrl + locale);
                 if (json == null)
                 {
                     Console.WriteLine($"Failed to fetch locales from {SourceLocaleUrl + locale}, skipping...");

--- a/src/Services/Alarms/AlarmControllerService.cs
+++ b/src/Services/Alarms/AlarmControllerService.cs
@@ -603,11 +603,14 @@
                     }
 
                     var oldGym = _mapDataCache.GetGym(gym.GymId).ConfigureAwait(false).GetAwaiter().GetResult();
-                    var changed = oldGym.Team != gym.Team
-                        || gym.InBattle
-                        || oldGym.SlotsAvailable != gym.SlotsAvailable;
-                    if (!changed)
-                        continue;
+                    if (oldGym != null)
+                    {
+                        var changed = oldGym.Team != gym.Team
+                            || gym.InBattle
+                            || oldGym.SlotsAvailable != gym.SlotsAvailable;
+                        if (!changed)
+                            continue;
+                    }
 
                     /*
                     var oldGym = _gyms[gym.GymId];

--- a/src/Services/Alarms/Filters/Models/WebhookFilterPokemonPvp.cs
+++ b/src/Services/Alarms/Filters/Models/WebhookFilterPokemonPvp.cs
@@ -54,7 +54,6 @@
             MaximumCP = 999999;
             MinimumRank = 1;
             MaximumRank = 100;
-            // TODO: Double check percent logic
             MinimumPercent = 0;
             MaximumPercent = 100;
             Gender = '*';

--- a/src/Services/Icons/Models/BaseIndexManifest.cs
+++ b/src/Services/Icons/Models/BaseIndexManifest.cs
@@ -38,11 +38,5 @@
 
         [JsonPropertyName("weather")]
         public HashSet<string> Weather { get; set; } = new();
-
-        [JsonPropertyName("0"), JsonIgnore]
-        public string IndexFile { get; set; } // home icons fix >.>
-
-        [JsonPropertyName("1"), JsonIgnore]
-        public string Overview { get; set; } // home/pmsf icons fix >.>
     }
 }

--- a/src/Services/Icons/UIconService.cs
+++ b/src/Services/Icons/UIconService.cs
@@ -97,8 +97,6 @@
             if (!IsStyleSelected(style, IconType.Pokemon))
                 return GetDefaultIcon(_iconStyles[style][IconType.Pokemon].Path);
 
-            // TODO: Check if style contains icon type
-
             var iconStyle = _iconStyles[style][IconType.Pokemon];
             var baseUrl = iconStyle.Path;
             var evolutionSuffixes = (evolutionId > 0 ? new[] { "_e" + evolutionId, string.Empty } : new[] { string.Empty }).ToList();
@@ -119,9 +117,6 @@
                                 var result = $"{pokemonId}{evolutionSuffix}{formSuffix}{costumeSuffix}{genderSuffix}{shinySuffix}.{IconFormat}";
                                 if (iconStyle.IndexList.Contains(result))
                                 {
-                                    // TODO: Review
-                                    //var subFolder = GetSubFolder(IconType.Pokemon);
-                                    //return $"{baseUrl}/{subFolder}/{result}";
                                     return $"{baseUrl}/{result}";
                                 }
                             }
@@ -542,13 +537,11 @@
                 //    continue;
 
                 // Get the remote form index file from the icon repository
-                var iconStyleSubFolder = GetSubFolder(iconType);
                 var indexPath = Path.Combine(
                     styleConfig.Path,
-                    iconStyleSubFolder,
                     IndexJson
                 );
-                var formsListJson = await NetUtils.Get(indexPath);
+                var formsListJson = await NetUtils.GetAsync(indexPath);
                 if (string.IsNullOrEmpty(formsListJson))
                 {
                     // Failed to get form list, skip...
@@ -557,8 +550,6 @@
                 }
                 try
                 {
-                    //Console.WriteLine($"IndexList: {formsListJson}");
-
                     // Deserialize json list to hash set
                     if (iconType == IconType.Base)
                     {

--- a/src/Services/StaticMap/StaticMapGenerator.cs
+++ b/src/Services/StaticMap/StaticMapGenerator.cs
@@ -1,11 +1,11 @@
 ﻿namespace WhMgr.Services.StaticMap
 {
     using System;
-    using System.Net;
-    using System.Net.Http;
     using System.Text;
-    
+
+    using WhMgr.Common;
     using WhMgr.Extensions;
+    using WhMgr.Utilities;
 
     public class StaticMapGenerator : IStaticMapGenerator
     {
@@ -28,19 +28,24 @@
                 pokestops = _options.Pokestops,
                 gyms = _options.Gyms,
                 url2 = _options.SecondaryImageUrl,
-                team_id = _options.Team,
+                team = _options.Team,
+                team_id = Convert.ToInt32(_options.Team ?? PokemonTeam.Neutral),
                 regeneratable = _options.Regeneratable,
                 pregenerated = _options.Pregenerate,
                 path = _options.PolygonPath,
             };
-            var payloadJson = payload.ToJson();
-            var url = BuildUrl();
-            var result = SendRequest(url, payloadJson);
-            var responseUrl = $"{_options.BaseUrl}/{_options.TemplateType.ToString().ToLower()}/pregenerated/{result}";
-            return responseUrl;
+            var url = BuildUrl(_options.Pregenerate);
+            if (_options.Pregenerate)
+            {
+                var payloadJson = payload.ToJson();
+                var result = NetUtils.Post(url, payloadJson);
+                var responseUrl = $"{_options.BaseUrl}/{_options.TemplateType.ToString().ToLower()}/pregenerated/{result}";
+                return responseUrl;
+            }
+            return url;
         }
 
-        private string BuildUrl()
+        private string BuildUrl(bool pregenerate)
         {
             var sb = new StringBuilder();
             sb.Append(_options.BaseUrl);
@@ -49,45 +54,37 @@
             sb.Append('/');
             sb.Append(_options.MapType.ToString().ToLower());
             sb.Append('?');
-            sb.Append($"pregenerate={_options.Pregenerate.ToString().ToLower()}");
-            sb.Append('&');
-            sb.Append($"regeneratable={_options.Regeneratable.ToString().ToLower()}");
-            sb.Append('&');
             sb.Append($"lat={_options.Latitude}");
             sb.Append('&');
             sb.Append($"lon={_options.Longitude}");
             sb.Append('&');
             sb.Append($"url2={_options.SecondaryImageUrl}");
+
+            if (pregenerate)
+            {
+                sb.Append('&');
+                sb.Append($"pregenerate={_options.Pregenerate.ToString().ToLower()}");
+                sb.Append('&');
+                sb.Append($"regeneratable={_options.Regeneratable.ToString().ToLower()}");
+            }
+            else
+            {
+                if (_options.Team != PokemonTeam.All)
+                {
+                    sb.Append('&');
+                    sb.Append($"team={_options.Team}");
+                    sb.Append('&');
+                    sb.Append($"team_id={Convert.ToInt32(_options.Team)}");
+                }
+                if (!string.IsNullOrEmpty(_options.PolygonPath))
+                {
+                    sb.Append('&');
+                    sb.Append($"polygon={_options.PolygonPath}");
+                }
+            }
+
             var url = sb.ToString();
             return url;
-        }
-
-        private static string SendRequest(string url, string payload)
-        {
-            try
-            {
-                using var client = new HttpClient();
-                var mime = "application/json";
-                var requestMessage = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    RequestUri = new Uri(url),
-                    Headers =
-                    {
-                        { HttpRequestHeader.Accept.ToString(), mime },
-                        { HttpRequestHeader.ContentType.ToString(), mime },
-                    },
-                    Content = new StringContent(payload, Encoding.UTF8, mime),
-                };
-                var response = client.SendAsync(requestMessage).Result;
-                var responseData = response.Content.ReadAsStringAsync().Result;
-                return responseData;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error: {ex}");
-            }
-            return null;
         }
     }
 }

--- a/src/Services/StaticMap/StaticMapOptions.cs
+++ b/src/Services/StaticMap/StaticMapOptions.cs
@@ -19,7 +19,7 @@
 
         public string SecondaryImageUrl { get; set; }
 
-        public PokemonTeam? Team { get; set; }
+        public PokemonTeam? Team { get; set; } = PokemonTeam.All;
 
         public string PolygonPath { get; set; }
 

--- a/src/Services/Subscriptions/Models/PokemonSubscription.cs
+++ b/src/Services/Subscriptions/Models/PokemonSubscription.cs
@@ -32,7 +32,6 @@
         ]
         public int MinimumCP { get; set; }
 
-        // TODO: Create migration to fix default value for Pokemon max_cp subscriptions
         [
             JsonPropertyName("max_cp"),
             Column("max_cp"),

--- a/src/Services/Subscriptions/SubscriptionProcessorService.cs
+++ b/src/Services/Subscriptions/SubscriptionProcessorService.cs
@@ -38,7 +38,7 @@
         private readonly IBackgroundTaskQueue _taskQueue;
         private readonly Dictionary<int, bool> _rateLimitedMessagesSent; // subscription_id -> rateLimitedMessageSent
 
-        // TODO: Use BenchmarkTimes property
+        // TODO: Add BenchmarkTimes property in config
         public bool BenchmarkTimes { get; set; }
 
         public SubscriptionProcessorService(
@@ -57,7 +57,7 @@
             _mapDataCache = mapDataCache;
             _statsService = statsService;
             _taskQueue = (DefaultBackgroundTaskQueue)taskQueue;
-            _rateLimitedMessagesSent = new Dictionary<int, bool>();
+            _rateLimitedMessagesSent = new();
         }
 
         #region Subscription Processing

--- a/src/Services/VersionManager.cs
+++ b/src/Services/VersionManager.cs
@@ -54,10 +54,10 @@
                 var shaFilePath = Path.Combine(Directory.GetCurrentDirectory(), "../.gitsha");
                 sha = File.ReadAllLines(shaFilePath).FirstOrDefault().Trim(' ');
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 sha = "?";
-                Console.WriteLine($"[Error] Failed to read .gitsha");
+                Console.WriteLine($"[Error] Failed to read .gitsha: {ex}");
             }
             try
             {
@@ -69,9 +69,9 @@
                                          .Replace("/merge", null);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Console.WriteLine($"[Error] Failed to read .gitref");
+                Console.WriteLine($"[Error] Failed to read .gitref: {ex}");
             }
             if (string.IsNullOrEmpty(pullRequest))
             {
@@ -364,6 +364,12 @@
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; set; }
+
+        [JsonPropertyName("zipball_url")]
+        public string ZipballUrl { get; set; }
+
+        [JsonPropertyName("tarball_url")]
+        public string TarballUrl { get; set; }
     }
 
     public class Commit

--- a/src/Services/Webhook/Models/AccountData.cs
+++ b/src/Services/Webhook/Models/AccountData.cs
@@ -134,7 +134,9 @@
 
         private dynamic GetPropertiesAsync(AlarmMessageSettings properties)
         {
-            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId) ? properties.Client.Guilds[properties.GuildId] : null;
+            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId)
+                ? properties.Client.Guilds[properties.GuildId]
+                : null;
 
             var dict = new
             {

--- a/src/Services/Webhook/Models/PvpRankData.cs
+++ b/src/Services/Webhook/Models/PvpRankData.cs
@@ -39,7 +39,7 @@
         [JsonPropertyName("cp")]
         public uint? CP { get; set; }
 
-        // TODO: Implement PVP league rank cap
+        // TODO: Implement PVP Pokemon level cap
         [JsonPropertyName("cap")]
         public uint Cap { get; set; }
     }

--- a/src/Services/Webhook/Models/QuestData.cs
+++ b/src/Services/Webhook/Models/QuestData.cs
@@ -19,7 +19,7 @@
     using WhMgr.Services.Icons;
     using WhMgr.Services.StaticMap;
     using WhMgr.Services.Webhook.Models.Quests;
-    using WhMgr.Utilities;
+    using WhMgr.Services.Yourls;
 
     public sealed class QuestData : IWebhookData, IWebhookPoint
     {
@@ -156,9 +156,7 @@
             {
                 BaseUrl = staticMapConfig.Url,
                 MapType = StaticMapType.Quests,
-                TemplateType = staticMapConfig.Type == StaticMapTemplateType.StaticMap
-                    ? StaticMapTemplateType.StaticMap
-                    : StaticMapTemplateType.MultiStaticMap,
+                TemplateType = staticMapConfig.Type,
                 Latitude = Latitude,
                 Longitude = Longitude,
                 SecondaryImageUrl = properties.ImageUrl,
@@ -184,7 +182,9 @@
             var wazeMapsLocationLink = await urlShortener.CreateAsync(wazeMapsLink);
             var scannerMapsLocationLink = await urlShortener.CreateAsync(scannerMapsLink);
             var address = await ReverseGeocodingLookup.Instance.GetAddressAsync(new Coordinate(Latitude, Longitude));
-            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId) ? properties.Client.Guilds[properties.GuildId] : null;
+            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId)
+                ? properties.Client.Guilds[properties.GuildId]
+                : null;
 
             const string defaultMissingValue = "?";
             var dict = new
@@ -204,8 +204,8 @@
 
                 // Location properties
                 geofence = properties.City ?? defaultMissingValue,
-                lat = Latitude.ToString(),
-                lng = Longitude.ToString(),
+                lat = Latitude,
+                lng = Longitude,
                 lat_5 = Latitude.ToString("0.00000"),
                 lng_5 = Longitude.ToString("0.00000"),
 

--- a/src/Services/Webhook/Models/RaidData.cs
+++ b/src/Services/Webhook/Models/RaidData.cs
@@ -18,7 +18,7 @@
     using WhMgr.Services.Geofence.Geocoding;
     using WhMgr.Services.Icons;
     using WhMgr.Services.StaticMap;
-    using WhMgr.Utilities;
+    using WhMgr.Services.Yourls;
 
     public sealed class RaidData : IWebhookData, IWebhookPoint
     {
@@ -274,9 +274,7 @@
             {
                 BaseUrl = staticMapConfig.Url,
                 MapType = StaticMapType.Raids,
-                TemplateType = staticMapConfig.Type == StaticMapTemplateType.StaticMap
-                    ? StaticMapTemplateType.StaticMap
-                    : StaticMapTemplateType.MultiStaticMap,
+                TemplateType = staticMapConfig.Type,
                 Latitude = Latitude,
                 Longitude = Longitude,
                 SecondaryImageUrl = properties.ImageUrl,
@@ -304,21 +302,23 @@
             var startTimeLeft = now.GetTimeRemaining(StartTime).ToReadableStringNoSeconds();
             var endTimeLeft = now.GetTimeRemaining(EndTime).ToReadableStringNoSeconds();
             var powerUpEndTimeLeft = now.GetTimeRemaining(PowerUpEndTime).ToReadableStringNoSeconds();
-            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId) ? properties.Client.Guilds[properties.GuildId] : null;
+            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId)
+                ? properties.Client.Guilds[properties.GuildId]
+                : null;
 
             const string defaultMissingValue = "?";
             var dict = new
             {
                 // Raid boss properties
-                pkmn_id = PokemonId.ToString(),
+                pkmn_id = PokemonId,
                 pkmn_id_3 = PokemonId.ToString("D3"),
                 pkmn_name = name,
                 pkmn_img_url = properties.ImageUrl,
                 evolution = evo,
-                evolution_id = Convert.ToInt32(Evolution).ToString(),
+                evolution_id = Convert.ToInt32(Evolution),
                 evolution_id_3 = Evolution.ToString("D3"),
                 form,
-                form_id = Form.ToString(),
+                form_id = Form,
                 form_id_3 = Form.ToString("D3"),
                 costume,
                 costume_id = Costume.ToString(),
@@ -326,10 +326,10 @@
                 is_egg = IsEgg,
                 is_ex = IsExEligible,
                 is_ex_exclusive = IsExclusive,
-                sponsor_id = Convert.ToString(SponsorId),
+                sponsor_id = SponsorId,
                 ex_emoji = exEmoji,
-                team = Team.ToString(),
-                team_id = Convert.ToInt32(Team).ToString(),
+                team = Team,
+                team_id = Convert.ToInt32(Team),
                 team_emoji = teamEmoji,
                 cp = CP,
                 lvl = level,
@@ -345,10 +345,10 @@
                 types_emoji = typeEmojis,
                 weaknesses,
                 weaknesses_emoji = weaknessesEmoji,
-                perfect_cp = perfectRange.ToString(),
-                perfect_cp_boosted = boostedRange.ToString(),
-                worst_cp = worstRange.ToString(),
-                worst_cp_boosted = worstBoosted.ToString(),
+                perfect_cp = perfectRange,
+                perfect_cp_boosted = boostedRange,
+                worst_cp = worstRange,
+                worst_cp_boosted = worstBoosted,
                 is_ar = IsArScanEligible,
 
                 // Gym power up properties
@@ -368,8 +368,8 @@
 
                 // Location properties
                 geofence = properties.City ?? defaultMissingValue,
-                lat = Latitude.ToString(),
-                lng = Longitude.ToString(),
+                lat = Latitude,
+                lng = Longitude,
                 lat_5 = Latitude.ToString("0.00000"),
                 lng_5 = Longitude.ToString("0.00000"),
 

--- a/src/Services/Webhook/Models/WeatherData.cs
+++ b/src/Services/Webhook/Models/WeatherData.cs
@@ -18,7 +18,7 @@
     using WhMgr.Services.Geofence;
     using WhMgr.Services.Geofence.Geocoding;
     using WhMgr.Services.StaticMap;
-    using WhMgr.Utilities;
+    using WhMgr.Services.Yourls;
 
     [Table("weather")]
     public class WeatherData : IWebhookData, IWebhookPoint
@@ -209,9 +209,7 @@
             {
                 BaseUrl = staticMapConfig.Url,
                 MapType = StaticMapType.Weather,
-                TemplateType = staticMapConfig.Type == StaticMapTemplateType.StaticMap
-                    ? StaticMapTemplateType.StaticMap
-                    : StaticMapTemplateType.MultiStaticMap,
+                TemplateType = staticMapConfig.Type,
                 Latitude = Latitude,
                 Longitude = Longitude,
                 SecondaryImageUrl = properties.ImageUrl,
@@ -234,33 +232,35 @@
             var wazeMapsLocationLink = await urlShortener.CreateAsync(wazeMapsLink);
             var scannerMapsLocationLink = await urlShortener.CreateAsync(scannerMapsLink);
             var address = await ReverseGeocodingLookup.Instance.GetAddressAsync(new Coordinate(Latitude, Longitude));
-            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId) ? properties.Client.Guilds[properties.GuildId] : null;
+            var guild = properties.Client.Guilds.ContainsKey(properties.GuildId)
+                ? properties.Client.Guilds[properties.GuildId]
+                : null;
 
             const string defaultMissingValue = "?";
             var dict = new
             {
                 // Main properties
-                id = Id.ToString(),
+                id = Id,
                 weather_condition = weather,
                 has_weather = hasWeather,
                 weather = weather ?? defaultMissingValue,
                 weather_emoji = weatherEmoji ?? defaultMissingValue,
                 weather_img_url = properties.ImageUrl,//weatherImageUrl,
 
-                wind_direction = WindDirection.ToString(),
-                wind_level = WindLevel.ToString(),
-                raid_level = RainLevel.ToString(),
-                cloud_level = CloudLevel.ToString(),
-                fog_level = FogLevel.ToString(),
-                snow_level = SnowLevel.ToString(),
+                wind_direction = WindDirection,
+                wind_level = WindLevel,
+                raid_level = RainLevel,
+                cloud_level = CloudLevel,
+                fog_level = FogLevel,
+                snow_level = SnowLevel,
                 warn_weather = WarnWeather ?? false,
-                special_effect_level = SpecialEffectLevel.ToString(),
-                severity = Severity.ToString(),
+                special_effect_level = SpecialEffectLevel,
+                severity = Severity,
 
                 // Location properties
                 geofence = properties.City ?? defaultMissingValue,
-                lat = Latitude.ToString(),
-                lng = Longitude.ToString(),
+                lat = Latitude,
+                lng = Longitude,
                 lat_5 = Latitude.ToString("0.00000"),
                 lng_5 = Longitude.ToString("0.00000"),
 

--- a/src/Services/Webhook/Queue/IWebhookQueueManager.cs
+++ b/src/Services/Webhook/Queue/IWebhookQueueManager.cs
@@ -4,6 +4,10 @@
 
     public interface IWebhookQueueManager
     {
-        Task SendWebhook(string webhookUrl, string json);
+        void Start();
+
+        void Stop();
+
+        Task SendWebhook(string url, string json);
     }
 }

--- a/src/Services/Webhook/WebhookProcessorService.cs
+++ b/src/Services/Webhook/WebhookProcessorService.cs
@@ -551,7 +551,6 @@
                             if (!allowPokemon) return false;
                             break;
                         case FilterType.Include:
-                            // TODO: Make IsMissingStats configurable for EventPokemon config section
                             if (ignoreMissingStats && pokemon.IsMissingStats) return false;
                             // Only allow Pokemon if meets IV/PvP criteria
                             if (!allowPokemon) return false;

--- a/src/Services/Yourls/Models/UrlShortenerResponse.cs
+++ b/src/Services/Yourls/Models/UrlShortenerResponse.cs
@@ -1,0 +1,25 @@
+﻿namespace WhMgr.Services.Yourls.Models
+{
+    using System.Text.Json.Serialization;
+
+    public class UrlShortenerResponse
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("statusCode")]
+        public int StatusCode { get; set; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("shorturl")]
+        public string ShortUrl { get; set; }
+
+        [JsonPropertyName("url")]
+        public UrlShortenerResponseUrl Url { get; set; }
+    }
+}

--- a/src/Services/Yourls/Models/UrlShortenerResponseUrl.cs
+++ b/src/Services/Yourls/Models/UrlShortenerResponseUrl.cs
@@ -1,0 +1,23 @@
+﻿namespace WhMgr.Services.Yourls.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    public class UrlShortenerResponseUrl
+    {
+        [JsonPropertyName("keyword")]
+        public string Keyword { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("date")]
+        public DateTime Date { get; set; }
+
+        [JsonPropertyName("ip")]
+        public string IpAddress { get; set; }
+    }
+}

--- a/src/Services/Yourls/UrlShortener.cs
+++ b/src/Services/Yourls/UrlShortener.cs
@@ -1,13 +1,14 @@
-﻿namespace WhMgr.Utilities
+﻿namespace WhMgr.Services.Yourls
 {
     using System;
     using System.Text;
-    using System.Text.Json.Serialization;
     using System.Threading.Tasks;
     using System.Web;
 
     using WhMgr.Configuration;
     using WhMgr.Extensions;
+    using WhMgr.Services.Yourls.Models;
+    using WhMgr.Utilities;
 
     /// <summary>
     /// Url shortener class using yourls.org
@@ -49,7 +50,7 @@
                 sb.Append("&format=");
                 sb.Append(Configuration.Format);
                 var apiUrl = sb.ToString();
-                var json = await NetUtils.Get(apiUrl);
+                var json = await NetUtils.GetAsync(apiUrl);
                 if (string.IsNullOrEmpty(json))
                     return url;
 
@@ -62,59 +63,21 @@
             }
         }
     }
+}
 
-    /*
+/*
 {
-    "url": {
-        "keyword":"1",
-        "url":"https://www.google.com/maps?q=34.01,-117.01",
-        "title":"Google Maps",
-        "date":"2019-05-25 04:48:55",
-        "ip":"172.89.225.76"
-    },
-    "status":"success",
-    "message":"https://www.google.com/maps?q=34.01,-117.01[...] added to database",
+"url": {
+    "keyword":"1",
+    "url":"https://www.google.com/maps?q=34.01,-117.01",
     "title":"Google Maps",
-    "shorturl":"https://site.com/u/1",
-    "statusCode":200
+    "date":"2019-05-25 04:48:55",
+    "ip":"172.89.225.76"
+},
+"status":"success",
+"message":"https://www.google.com/maps?q=34.01,-117.01[...] added to database",
+"title":"Google Maps",
+"shorturl":"https://site.com/u/1",
+"statusCode":200
 }
-    */
-    public class UrlShortenerResponse
-    {
-        [JsonPropertyName("status")]
-        public string Status { get; set; }
-
-        [JsonPropertyName("statusCode")]
-        public int StatusCode { get; set; }
-
-        [JsonPropertyName("message")]
-        public string Message { get; set; }
-
-        [JsonPropertyName("title")]
-        public string Title { get; set; }
-
-        [JsonPropertyName("shorturl")]
-        public string ShortUrl { get; set; }
-
-        [JsonPropertyName("url")]
-        public UrlShortenerResponseUrl Url { get; set; }
-    }
-
-    public class UrlShortenerResponseUrl
-    {
-        [JsonPropertyName("keyword")]
-        public string Keyword { get; set; }
-
-        [JsonPropertyName("url")]
-        public string Url { get; set; }
-
-        [JsonPropertyName("title")]
-        public string Title { get; set; }
-
-        [JsonPropertyName("date")]
-        public DateTime Date { get; set; }
-
-        [JsonPropertyName("ip")]
-        public string IpAddress { get; set; }
-    }
-}
+*/

--- a/src/Strings.cs
+++ b/src/Strings.cs
@@ -49,10 +49,5 @@
         public const string ErrorLogFileName = "error.log";
 
         public const int DiscordMaximumMessageLength = 2048;
-
-        public const string All = "All";
-
-        public const string EmojiSchema = "<:{0}:{1}>";
-        public const string TypeEmojiSchema = "<:types_{0}:{1}>";
     }
 }

--- a/static/data/embedColors.json
+++ b/static/data/embedColors.json
@@ -27,7 +27,8 @@
       "normal": "#ff69b4",
       "glacial": "#6495ed",
       "mossy": "#507d2a",
-      "magnetic": "#808080"
+      "magnetic": "#808080",
+      "rainy": "#1da7de"
     },
     "invasions": "#ff0000"
   },

--- a/test/StaticMapTests.cs
+++ b/test/StaticMapTests.cs
@@ -40,8 +40,8 @@
                     marker = "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS/pokestop/0.png",
                 }
             };
-            var baseUrl = "http://10.0.0.2:9000";
-            //var baseUrl = "http://10.0.0.2:43200";
+            //var baseUrl = "http://10.0.0.2:9000";
+            var baseUrl = "http://10.0.0.2:43200";
             var lat = 34.01;
             var lon = -117.01;
             var url2 = "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS/pokemon/201_f9.png";
@@ -58,6 +58,30 @@
                 Team = Common.PokemonTeam.Valor,
                 Pregenerate = true,
                 Regeneratable = true,
+            });
+            var id = staticMap.GenerateLink();
+            var url = baseUrl + "/staticmap/pregenerated/" + id;
+            Console.WriteLine($"FinalUrl: {url}");
+        }
+
+        [Test]
+        public void Test_StaticMapPokemon_NoPregenerate_ReturnsIsTrue()
+        {
+            //var baseUrl = "http://10.0.0.2:9000";
+            var baseUrl = "http://10.0.0.2:43200";
+            var lat = 34.03;
+            var lon = -117.03;
+            var url2 = "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS/pokemon/201_f4.png";
+            var staticMap = new StaticMapGenerator(new StaticMapOptions
+            {
+                BaseUrl = baseUrl,
+                MapType = StaticMapType.Pokemon,
+                TemplateType = StaticMapTemplateType.StaticMap,
+                Latitude = lat,
+                Longitude = lon,
+                SecondaryImageUrl = url2,
+                Pregenerate = false,
+                Regeneratable = false,
             });
             var id = staticMap.GenerateLink();
             var url = baseUrl + "/staticmap/pregenerated/" + id;


### PR DESCRIPTION
Fixes: #276 

- Add missing team_id property for StaticMap payload.
- Fix typo with Invasions template.
- Reduce gym and pokestop icon size for StaticMaps.
- Remove normal pokestop icon from StaticMap lure templates.
- Fix Pokemon icons reference in example config.
- Allow for non pregenerated StaticMaps.
- Fix issue with Pokemon StaticMap template if no gyms or pokestops provided.
- Update config docs.
- Update defaults.json file.
- Update emojis logic.
- Fix ex gym emoji DTS typo.
- Update Discord color config.
- Filter/display PVP rankings based on minimum rank value from config.