### PR TITLE
Channel Alarm PVP Filters Simplification

### DIFF
--- a/docs/config/filters.md
+++ b/docs/config/filters.md
@@ -25,7 +25,7 @@ Filters allow you to narrow down what is reported. All filters are optional and 
 		// depending on the interested ranks.
 		"pvp": {
 			// Little league rank filtering
-			"little": [{
+			"little": {
 				// Minimum rank of #1 for PVP rank stats
 				"min_rank": 1,
 				// Maximum rank of #5 for PVP rank stats
@@ -40,28 +40,23 @@ Filters allow you to narrow down what is reported. All filters are optional and 
 				"max_percent": 100,
 				// Gender filtering requirement (*, m, or f)
 				"gender": "*"
-			}],
+			},
 			// Great league rank filtering
-			"great": [{
+			"great": {
 				"min_rank": 1,
 				"max_rank": 5,
 				"min_cp": 1400,
 				"max_cp": 1500,
 				"gender": "m"
-			}],
+			},
 			// Ultra league rank filtering
-			"ultra": [{
+			"ultra": {
 				"min_rank": 1,
 				"max_rank": 25,
 				"min_cp": 2400,
 				"max_cp": 2500,
 				"gender": "f"
-			},{
-				"min_rank": 1,
-				"max_rank": 5,
-				"min_cp": 2300,
-				"max_cp": 2400
-			}]
+			}
 		},
 		"type": "Include", // Include or Exclude the `pokemon` list
 		"is_event": false, // Only send Pokemon checked with event accounts (GoFest, etc)

--- a/examples/filters/default.json
+++ b/examples/filters/default.json
@@ -17,7 +17,7 @@
             // Add or remove any PVP league filtering keys
             // depending on the interested ranks
             // Little league rank filtering
-            "little": [{
+            "little": {
                 // Minimum rank of #1 for PVP rank stats
                 "min_rank": 1,
                 // Maximum rank of #5 for PVP rank stats
@@ -34,7 +34,7 @@
                 "gender": "*"
             }],
             // Great league rank filtering
-            "great": [{
+            "great": {
                 "min_rank": 1,
                 "max_rank": 5,
                 "min_cp": 1400,
@@ -42,18 +42,13 @@
                 "gender": "m"
             }],
             // Ultra league rank filtering
-            "ultra": [{
+            "ultra": {
                 "min_rank": 1,
                 "max_rank": 25,
                 "min_cp": 2400,
                 "max_cp": 2500,
                 "gender": "f"
-            },{
-                "min_rank": 1,
-                "max_rank": 5,
-                "min_cp": 2300,
-                "max_cp": 2400
-            }]
+            }
         },
         "type": "Include", // Include or Exclude the `pokemon` list
         "is_event": false, // Only send Pokemon checked with event accounts (GoFest, etc)

--- a/examples/filters/pvp1500cp.json
+++ b/examples/filters/pvp1500cp.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 1500,
         "pvp": {
-            "great": [{
+            "great": {
                 "min_rank": 1,
                 "max_rank": 25,
                 "min_cp": 1400,
                 "max_cp": 1500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp1500cp_rank1.json
+++ b/examples/filters/pvp1500cp_rank1.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 1500,
         "pvp": {
-            "great": [{
+            "great": {
                 "min_rank": 1,
                 "max_rank": 1,
                 "min_cp": 1400,
                 "max_cp": 1500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp1500cp_rank5.json
+++ b/examples/filters/pvp1500cp_rank5.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 1500,
         "pvp": {
-            "great": [{
+            "great": {
                 "min_rank": 1,
                 "max_rank": 5,
                 "min_cp": 1400,
                 "max_cp": 1500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp2500cp.json
+++ b/examples/filters/pvp2500cp.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 2500,
         "pvp": {
-            "ultra": [{
+            "ultra": {
                 "min_rank": 1,
                 "max_rank": 25,
                 "min_cp": 2400,
                 "max_cp": 2500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp2500cp_rank1.json
+++ b/examples/filters/pvp2500cp_rank1.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 2500,
         "pvp": {
-            "ultra": [{
+            "ultra": {
                 "min_rank": 1,
                 "max_rank": 1,
                 "min_cp": 2400,
                 "max_cp": 2500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp2500cp_rank5.json
+++ b/examples/filters/pvp2500cp_rank5.json
@@ -8,13 +8,13 @@
 		"min_cp": 0,
 		"max_cp": 2500,
 		"pvp": {
-			"ultra": [{
+			"ultra": {
 				"min_rank": 1,
 				"max_rank": 5,
 				"min_cp": 2400,
 				"max_cp": 2500,
 				"gender": "*"
-			}]
+			}
 		},
 		"type": "Include",
 		"ignore_missing": true

--- a/examples/filters/pvp500cp.json
+++ b/examples/filters/pvp500cp.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 500,
         "pvp": {
-            "little": [{
+            "little": {
                 "max_rank": 25,
                 "min_rank": 1,
                 "min_cp": 450,
                 "max_cp": 500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp500cp_rank1.json
+++ b/examples/filters/pvp500cp_rank1.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 500,
         "pvp": {
-            "little": [{
+            "little": {
                 "min_rank": 1,
                 "max_rank": 1,
                 "min_cp": 450,
                 "max_cp": 500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/examples/filters/pvp500cp_rank5.json
+++ b/examples/filters/pvp500cp_rank5.json
@@ -8,13 +8,13 @@
         "min_cp": 0,
         "max_cp": 500,
         "pvp": {
-            "little": [{
+            "little": {
                 "min_rank": 1,
                 "max_rank": 5,
                 "min_cp": 450,
                 "max_cp": 500,
                 "gender": "*"
-            }]
+            }
         },
         "type": "Include",
         "ignore_missing": true

--- a/src/Controllers/AdminApiController.cs
+++ b/src/Controllers/AdminApiController.cs
@@ -640,14 +640,14 @@
             var filterJson = dict["filter"].ToString();
             var filter = filterJson.FromJson<WebhookFilter>();
 
-            // Save json
-            var json = filter.ToJson();
             var path = Path.Combine(Strings.FiltersFolder, name + ".json");
             if (System.IO.File.Exists(path))
             {
                 return SendErrorResponse($"Failed to create filter '{name}', filter already exists.");
             }
 
+            // Save json
+            var json = filter.ToJson();
             await WriteDataAsync(path, json);
 
             return new JsonResult(new

--- a/src/Services/Alarms/AlarmControllerService.cs
+++ b/src/Services/Alarms/AlarmControllerService.cs
@@ -121,31 +121,29 @@
                             {
                                 return false;
                             }
-                            var filterRankings = pvpPokemonFilters[league];
+                            var filterRanking = pvpPokemonFilters[league];
                             var pokemonRankings = pokemon.PvpRankings[league];
                             // Check if any alarm filter matches Pokemon PVP rank for each available league
-                            var result = filterRankings.Exists(filter =>
-                                pokemonRankings.Exists(rank =>
-                                {
-                                    //var percentage = Math.Round(Convert.ToDouble(rank.Percentage) * 100.0, 2);
-                                    var matches =
-                                    (
-                                        Filters.Filters.MatchesPvPRank(rank.Rank ?? 0, filter.MinimumRank, filter.MaximumRank)
-                                        ||
-                                        Filters.Filters.MatchesPvPRank(rank.CompetitionRank, filter.MinimumRank, filter.MaximumRank)
-                                        ||
-                                        Filters.Filters.MatchesPvPRank(rank.DenseRank, filter.MinimumRank, filter.MaximumRank)
-                                        ||
-                                        Filters.Filters.MatchesPvPRank(rank.OrdinalRank, filter.MinimumRank, filter.MaximumRank)
-                                    )
-                                    &&
-                                    Filters.Filters.MatchesCP((uint)rank.CP, filter.MinimumCP, filter.MaximumCP)
-                                    &&
-                                    Filters.Filters.MatchesGender(rank.Gender, filter.Gender);
-                                    // TODO: Reimplement rank product stat percentage filtering (filter.MinimumPercent <= rank.Percentage && filter.MaximumPercent >= rank.Percentage);
-                                    return matches;
-                                })
-                            );
+                            var result = pokemonRankings.Exists(rank =>
+                            {
+                                //var percentage = Math.Round(Convert.ToDouble(rank.Percentage) * 100.0, 2);
+                                var matches =
+                                (
+                                    Filters.Filters.MatchesPvPRank(rank.Rank ?? 0, filterRanking.MinimumRank, filterRanking.MaximumRank)
+                                    ||
+                                    Filters.Filters.MatchesPvPRank(rank.CompetitionRank, filterRanking.MinimumRank, filterRanking.MaximumRank)
+                                    ||
+                                    Filters.Filters.MatchesPvPRank(rank.DenseRank, filterRanking.MinimumRank, filterRanking.MaximumRank)
+                                    ||
+                                    Filters.Filters.MatchesPvPRank(rank.OrdinalRank, filterRanking.MinimumRank, filterRanking.MaximumRank)
+                                )
+                                &&
+                                Filters.Filters.MatchesCP((uint)rank.CP, filterRanking.MinimumCP, filterRanking.MaximumCP)
+                                &&
+                                Filters.Filters.MatchesGender(rank.Gender, filterRanking.Gender);
+                                // TODO: Reimplement rank product stat percentage filtering (filter.MinimumPercent <= rank.Percentage && filter.MaximumPercent >= rank.Percentage);
+                                return matches;
+                            });
                             return result;
                         }) ?? false;
 

--- a/src/Services/Alarms/Filters/Models/WebhookFilterPokemon.cs
+++ b/src/Services/Alarms/Filters/Models/WebhookFilterPokemon.cs
@@ -86,7 +86,7 @@
         /// Gets or sets the Pokemon eligible PvP ranking filtering
         /// </summary>
         [JsonPropertyName("pvp")]
-        public Dictionary<PvpLeague, List<WebhookFilterPokemonPvp>> Pvp { get; set; }
+        public Dictionary<PvpLeague, WebhookFilterPokemonPvp> Pvp { get; set; }
 
         /// <summary>
         /// Gets or sets a value determining if webhook Pokemon filter has PvP ranking filters
@@ -128,7 +128,7 @@
             MaximumCP = 999999;
             MinimumLevel = 0;
             MaximumLevel = 100; // Support for when they increase level cap. :wink:
-            Pvp = new Dictionary<PvpLeague, List<WebhookFilterPokemonPvp>>();
+            Pvp = new Dictionary<PvpLeague, WebhookFilterPokemonPvp>();
             Gender = '*';
             Size = PokemonSize.All;
         }


### PR DESCRIPTION
Changes channel alarm Pokemon PvP filters to accept an object with one filter for the specified league instead of a list.

Current implementation:
```json
    ...
    "pvp": {
        // Add or remove any PVP league filtering keys
        // depending on the interested ranks
        // Little league rank filtering
        "little": [{
            // Minimum rank of #1 for PVP rank stats
            "min_rank": 1,
            // Maximum rank of #5 for PVP rank stats
            "max_rank": 5,
            // Minimum CP value of 400 for PVP rank stats
            "min_cp": 400,
            // Maximum CP value of 500 for PVP rank stats
            "max_cp": 500,
            // Minimum PVP product stat
            "min_percent": 90,
            // Maximum PVP product stat
            "max_percent": 100,
            // Gender filtering requirement (*, m, or f)
            "gender": "*"
        }],
        // Great league rank filtering
        "great": [{
            "min_rank": 1,
            "max_rank": 5,
            "min_cp": 1400,
            "max_cp": 1500,
            "gender": "m"
        }],
        // Ultra league rank filtering
        "ultra": [{
            "min_rank": 1,
            "max_rank": 25,
            "min_cp": 2400,
            "max_cp": 2500,
            "gender": "f"
        },{
            "min_rank": 1,
            "max_rank": 5,
            "min_cp": 2300,
            "max_cp": 2400
        }]
    },
    ...
```

New implementation:  
```json
    ...
    "pvp": {
        // Add or remove any PVP league filtering keys
        // depending on the interested ranks
        // Little league rank filtering
        "little": {
            // Minimum rank of #1 for PVP rank stats
            "min_rank": 1,
            // Maximum rank of #5 for PVP rank stats
            "max_rank": 5,
            // Minimum CP value of 400 for PVP rank stats
            "min_cp": 400,
            // Maximum CP value of 500 for PVP rank stats
            "max_cp": 500,
            // Minimum PVP product stat
            "min_percent": 90,
            // Maximum PVP product stat
            "max_percent": 100,
            // Gender filtering requirement (*, m, or f)
            "gender": "*"
        },
        // Great league rank filtering
        "great": {
            "min_rank": 1,
            "max_rank": 5,
            "min_cp": 1400,
            "max_cp": 1500,
            "gender": "m"
        },
        // Ultra league rank filtering
        "ultra": {
            "min_rank": 1,
            "max_rank": 25,
            "min_cp": 2400,
            "max_cp": 2500,
            "gender": "f"
        }
    },
    ...
```