### PR TITLE
Fix Pokemon Embed Type Emojis

### DIFF
--- a/src/Data/GameMaster.cs
+++ b/src/Data/GameMaster.cs
@@ -110,6 +110,10 @@
             var useForm = /*!pkmn.Attack.HasValue &&*/ formId > 0 && pkmn.Forms.ContainsKey(formId);
             var pkmnForm = useForm ? pkmn.Forms[formId] : pkmn;
             pkmnForm.Name = pkmn.Name;
+            // Check if Pokemon is form and Pokemon types provided, if not use normal Pokemon types as fallback
+            pkmnForm.Types = useForm && (pkmn.Forms[formId].Types?.Count ?? 0) > 0
+                ? pkmn.Forms[formId].Types
+                : pkmn.Types;
             return pkmnForm;
         }
 

--- a/src/Services/Webhook/Models/PokemonData.cs
+++ b/src/Services/Webhook/Models/PokemonData.cs
@@ -342,6 +342,8 @@
 
         #endregion
 
+        #region Public Methods
+
         /// <summary>
         /// Set despawn times because .NET doesn't support Unix timestamp
         /// deserialization to <seealso cref="DateTime"/> class by default.
@@ -425,6 +427,10 @@
                 Embeds = new List<DiscordEmbedMessage> { eb },
             };
         }
+
+        #endregion
+
+        #region Private Methods
 
         private async Task<dynamic> GetPropertiesAsync(AlarmMessageSettings properties)
         {
@@ -629,5 +635,7 @@
             };
             return dict;
         }
+
+        #endregion
     }
 }

--- a/src/WhMgr.csproj
+++ b/src/WhMgr.csproj
@@ -77,10 +77,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Web\Api\Requests\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Remove="ClientApp\package.json" />
     <Content Remove="ClientApp\package-lock.json" />
     <Content Remove="ClientApp\public\manifest.json" />
@@ -95,6 +91,13 @@
 	<Content Include="Views\**\*.*">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Web\Api\Requests\**" />
+    <Content Remove="Web\Api\Requests\**" />
+    <EmbeddedResource Remove="Web\Api\Requests\**" />
+    <None Remove="Web\Api\Requests\**" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\README.md">


### PR DESCRIPTION
Fix issue with Pokemon type emojis being empty if pulled form Pokemon from game master and no types assigned to form. If so, assign normal forms Pokemon types.