### PR TITLE
Add Maximum Queue Capacity

### DIFF
--- a/src/Defaults.cs
+++ b/src/Defaults.cs
@@ -38,6 +38,9 @@
         [JsonPropertyName("max_queue_size_warning")]
         public ushort MaximumQueueSizeWarning { get; set; }
 
+        [JsonPropertyName("max_queue_capacity")]
+        public ushort MaximumQueueCapacity { get; set; }
+
 
         // Location map format strings
         [JsonPropertyName("google_maps")]
@@ -82,6 +85,7 @@
 
             MaximumQueueBatchSize = 10;
             MaximumQueueSizeWarning = 100;
+            MaximumQueueCapacity = 4096;
 
             GoogleMaps = "https://maps.google.com/maps?q={0},{1}";
             AppleMaps = "https://maps.apple.com/maps?daddr={0},{1}";

--- a/src/Defaults.cs
+++ b/src/Defaults.cs
@@ -83,7 +83,7 @@
             MinimumCP = 0;
             MaximumCP = 99999;
 
-            MaximumQueueBatchSize = 10;
+            MaximumQueueBatchSize = 25;
             MaximumQueueSizeWarning = 100;
             MaximumQueueCapacity = 4096;
 

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -110,8 +110,8 @@ namespace WhMgr
             // TODO: Use scoped background services
             services.AddSingleton<IBackgroundTaskQueue>(_ =>
             {
-                // TODO: Get max subscription queue capacity config value
-                var maxQueueCapacity = 2048;
+                // Get max subscription queue capacity config value
+                var maxQueueCapacity = Strings.Defaults.MaximumQueueCapacity;
                 return new DefaultBackgroundTaskQueue(maxQueueCapacity);
             });
 

--- a/static/data/defaults.json
+++ b/static/data/defaults.json
@@ -33,6 +33,7 @@
     },
     "max_queue_batch_size": 10,
     "max_queue_size_warning": 50,
+    "max_queue_capacity": 4096,
     "all": "All",
     "emoji_schema": "<:{0}:{1}>",
     "type_emoji_schema": "<:types_{0}:{1}>",

--- a/static/data/defaults.json
+++ b/static/data/defaults.json
@@ -31,7 +31,7 @@
             "max_league_cp": 2500,
         }
     },
-    "max_queue_batch_size": 10,
+    "max_queue_batch_size": 25,
     "max_queue_size_warning": 50,
     "max_queue_capacity": 4096,
     "all": "All",


### PR DESCRIPTION
- Adds configurable `max_queue_capacity` property to `static/data/defaults.json` with default value of 4096
- Increases default value of `max_queue_batch_size` from 10 to 25